### PR TITLE
Beta-7: Dark Samus Hotfix, Stream Fixes, ARCadia toggling at runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcropolis"
-version = "2.0.0-beta6"
+version = "2.0.0-beta7"
 authors = ["Raytwo <raytwost@gmail.com>, jam1garner <jam@jam1.re>, blujay <the.blu.dev@gmail.com>, CoolSonicKirby <alihussain2001@gmail.com>"]
 edition = "2018"
 

--- a/src/fs/visit.rs
+++ b/src/fs/visit.rs
@@ -11,10 +11,16 @@ use walkdir::WalkDir;
 
 use super::{ModFile, SmashPath, RejectionReason};
 
+pub struct DiscoveryResults {
+    pub accepted: HashMap<Hash40, ModFile>,
+    pub rejected: Vec<(PathBuf, RejectionReason)>,
+    pub stream: HashMap<Hash40, ModFile>
+}
+
 /// Discover every file in a directory and its sub-directories.  
 /// Files starting with a period are filtered out, and only the files with relevant regions are kept.  
 /// This signifies that if your goal is to simply get all the files, this is not the method to use.
-pub fn discovery<Arc: ArcLookup>(arc: &Arc, path: &PathBuf, accepted: &mut HashMap<Hash40, ModFile>, rejected: &mut Vec<(PathBuf, RejectionReason)>, stream: &mut HashMap<Hash40, ModFile>) {
+pub fn discovery<Arc: ArcLookup>(arc: &Arc, path: &PathBuf, results: &mut DiscoveryResults) {
     for mod_file in WalkDir::new(path)
         .min_depth(1)
         .into_iter()
@@ -29,34 +35,34 @@ pub fn discovery<Arc: ArcLookup>(arc: &Arc, path: &PathBuf, accepted: &mut HashM
                         }
                     }
                     let hash = smash_path.hash40().unwrap();
-                    if let Some(previous) = accepted.get(&hash) {
-                        rejected.push((mod_file.path().to_path_buf(), RejectionReason::DuplicateFile(previous.path.to_path_buf())));
+                    if let Some(previous) = results.accepted.get(&hash) {
+                        results.rejected.push((mod_file.path().to_path_buf(), RejectionReason::DuplicateFile(previous.path.to_path_buf())));
                     } else {
                         match arc.get_file_path_index_from_hash(hash) {
                             Ok(_) => {
-                                accepted.insert(hash, ModFile::new(
+                                results.accepted.insert(hash, ModFile::new(
                                     path.to_path_buf(),
                                     smash_path
                                 ));
                             },
                             Err(_) => {
                                 if smash_path.is_stream() {
-                                    if let Some(previous) = stream.get(&hash) {
-                                        rejected.push((mod_file.path().to_path_buf(), RejectionReason::DuplicateFile(previous.path.to_path_buf())));
+                                    if let Some(previous) = results.stream.get(&hash) {
+                                        results.rejected.push((mod_file.path().to_path_buf(), RejectionReason::DuplicateFile(previous.path.to_path_buf())));
                                     } else {
-                                        stream.insert(hash, ModFile::new(
+                                        results.stream.insert(hash, ModFile::new(
                                             path.to_path_buf(),
                                             smash_path
                                         ));
                                     }
                                 } else {
-                                    rejected.push((mod_file.path().to_path_buf(), RejectionReason::NotFound(smash_path)));
+                                    results.rejected.push((mod_file.path().to_path_buf(), RejectionReason::NotFound(smash_path)));
                                 }
                             }
                         }
                     }
                 } else {
-                    rejected.push((mod_file.path().to_path_buf(), RejectionReason::MissingExtension));
+                    results.rejected.push((mod_file.path().to_path_buf(), RejectionReason::MissingExtension));
                 }
             }
         }
@@ -67,7 +73,7 @@ pub fn discovery<Arc: ArcLookup>(arc: &Arc, path: &PathBuf, accepted: &mut HashM
 /// Files starting with a period are filtered out, and only the files with relevant regions are kept.  
 /// This signifies that if your goal is to simply get all the files, this is not the method to use.  
 /// This method exists to support backward compatibility with Ultimate Mod Manager.  
-pub fn umm_discovery<Arc: ArcLookup>(arc: &Arc, dir: &PathBuf, accepted: &mut HashMap<Hash40, ModFile>, rejected: &mut Vec<(PathBuf, RejectionReason)>, stream: &mut HashMap<Hash40, ModFile>) {
+pub fn umm_discovery<Arc: ArcLookup>(arc: &Arc, dir: &PathBuf, results: &mut DiscoveryResults) {
     for mod_directory in WalkDir::new(dir)
         .min_depth(1)
         .max_depth(1)
@@ -75,7 +81,7 @@ pub fn umm_discovery<Arc: ArcLookup>(arc: &Arc, dir: &PathBuf, accepted: &mut Ha
         .filter_entry(|entry| !entry.file_name().to_str().unwrap().starts_with('.')) {
         if let Ok(mod_directory) = mod_directory {
             if mod_directory.file_type().is_dir() {
-                discovery(arc, &mod_directory.into_path(), accepted, rejected, stream);
+                discovery(arc, &mod_directory.into_path(), results);
             }
         }        
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,10 @@ lazy_static! {
         Hash40::from("fighter/pacman/model/firehydrant/c00/firehydrant.lvd"),
         Hash40::from("fighter/pickel/model/forge/c00/forge.lvd")
     ];
+
+    static ref BLACKLISTED_DIRECTORIES: [Hash40; 1] = [
+        Hash40::from("fighter/samusd")
+    ];
 }
 
 fn get_filectx_by_index<'a>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(proc_macro_hygiene)]
 #![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(map_try_insert)]
 #![allow(dead_code)]
 #![allow(unaligned_references)]
@@ -57,11 +58,22 @@ lazy_static! {
 
     static ref BLACKLISTED_FILES: [Hash40; 2] = [
         Hash40::from("fighter/pacman/model/firehydrant/c00/firehydrant.lvd"),
-        Hash40::from("fighter/pickel/model/forge/c00/forge.lvd")
+        Hash40::from("fighter/pickel/model/forge/c00/forge.lvd"),
     ];
 
     static ref BLACKLISTED_DIRECTORIES: [Hash40; 1] = [
-        Hash40::from("fighter/samusd")
+        Hash40::from("fighter/samusd/c04"),
+    ];
+
+    static ref RESHARED_DIRECTORIES: [(Hash40, Hash40); 8] = [
+        (Hash40::from("fighter/samusd/result/c00"), Hash40::from("fighter/samusd/c00")),
+        (Hash40::from("fighter/samusd/result/c01"), Hash40::from("fighter/samusd/c01")),
+        (Hash40::from("fighter/samusd/result/c02"), Hash40::from("fighter/samusd/c02")),
+        (Hash40::from("fighter/samusd/result/c03"), Hash40::from("fighter/samusd/c03")),
+        (Hash40::from("fighter/samusd/result/c04"), Hash40::from("fighter/samusd/c04")),
+        (Hash40::from("fighter/samusd/result/c05"), Hash40::from("fighter/samusd/c05")),
+        (Hash40::from("fighter/samusd/result/c06"), Hash40::from("fighter/samusd/c06")),
+        (Hash40::from("fighter/samusd/result/c07"), Hash40::from("fighter/samusd/c07")),
     ];
 }
 
@@ -246,7 +258,7 @@ fn replace_extension_callback(extension: Hash40, index: FileInfoIndiceIdx) {
     }
 
     // if the file wasn't loaded by any of the callbacks, search for a fallback
-    if MOD_FILES.read().0.contains_key(&FileIndex::Regular(index)) {
+    if MOD_FILES.read().modded_files.contains_key(&FileIndex::Regular(index)) {
         replace_file_by_index(FileIndex::Regular(index));
     } else {
         // load vanilla
@@ -470,6 +482,9 @@ fn initial_loading(_ctx: &InlineCtx) {
     unsafe {
         nn::oe::SetCpuBoostMode(nn::oe::CpuBoostMode::Boost);
         ORIGINAL_SHARED_INDEX = LoadedTables::get_arc().get_shared_data_index();
+        for (to_unshare, source) in RESHARED_DIRECTORIES.iter() {
+            unsharing::reshare_directory(*to_unshare, *source);
+        }
         unsharing::unshare_files(Hash40::from("fighter"));
         unsharing::unshare_files(Hash40::from("stage"));
         lazy_static::initialize(&MOD_FILES);

--- a/src/menus/arcadia.rs
+++ b/src/menus/arcadia.rs
@@ -236,11 +236,14 @@ pub fn show_arcadia() {
                 }
 
                 info!("[menus::show_arcadia] ---------------------------");
-
-                if modified_detected {
-                    skyline_web::DialogOk::ok("Mods have been toggled!<br>Please reboot Smash to refresh ARCropolis' cache to prevent the game from crashing.");
-                    // skyline::nn::oe::RestartProgramNoArgs();
-                }
+            }
+            if modified_detected {
+                let thread = std::thread::spawn(|| crate::replacement_files::MOD_FILES.write().reinitialize());
+                skyline_web::DialogOk::ok("Mods have been toggled!<br>Please be patient, ARCropolis is refreshing its cache.");
+                thread.join().unwrap();
+                skyline_web::DialogOk::ok("ARCropolis has refreshed its cache.");
+                // skyline_web::DialogOk::ok("Mods have been toggled!<br>Please reboot Smash to refresh ARCropolis' cache to prevent the game from crashing.");
+                // skyline::nn::oe::RestartProgramNoArgs();
             }
         }
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -56,16 +56,11 @@ fn lookup_by_stream_hash(
                 original!()(out_path, loaded_arc, size_out, offset_out, hash)
             }
             // Load the file from the SD
-            crate::replacement_files::FileBacking::ModFile(_) => {
-                let path = match file_ctx.path() {
-                    Some(path) => path,
-                    None => {
-                        original!()(out_path, loaded_arc, size_out, offset_out, hash);
-                        return;
-                    }
-                };
+            crate::replacement_files::FileBacking::ModFile(modfile) => {
+                let path = modfile.full_path();
 
                 // Daily reminder that Raytwo did not write this so please don't blame him for it looking bad.
+                // blujay here, definitely going to blame Ray for the code looking like this
                 unsafe {
                     *size_out = path.metadata().unwrap().len() as usize;
                     *offset_out = 0;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -49,7 +49,7 @@ fn lookup_by_stream_hash(
     hash: Hash40,
 ) {
     // If we have a FileCtx for this stream, use it
-    if let Some(file_ctx) = MOD_FILES.read().0.get(&FileIndex::Stream(hash)) {
+    if let Some(file_ctx) = MOD_FILES.read().modded_files.get(&FileIndex::Stream(hash)) {
         match &file_ctx.file {
             // Goes without saying
             crate::replacement_files::FileBacking::LoadFromArc => {

--- a/src/unsharing.rs
+++ b/src/unsharing.rs
@@ -329,6 +329,10 @@ pub fn unshare_recursively(directory: Hash40, loaded_tables: &LoadedTables, unsh
         }
     }
 
+    if crate::BLACKLISTED_DIRECTORIES.contains(&directory) {
+        return;
+    }
+
     let arc = LoadedTables::get_arc();
     
     let dir_info = if let Ok(info) = arc.get_dir_info_from_hash(directory) {


### PR DESCRIPTION
Changes:
* Dark Samus is (so far) the only character that has their entire directory blacklisted from being unshared. This is a temporary change until a proper fix can be implemented.
* Stream files are now properly replaced/added
* Toggling mods with ARCadia no longer requires a restart of the game.