### PR TITLE
Add ZR as a button to open the mod manager

### DIFF
--- a/src/fs/discover.rs
+++ b/src/fs/discover.rs
@@ -40,10 +40,10 @@ pub fn perform_discovery() -> LaunchPad<StandardLoader> {
 
     let legacy_discovery = config::legacy_discovery();
 
-    // Open the ARCropolis menu if Minus is held before mod discovery
-    if ninput::any::is_down(ninput::Buttons::PLUS) {
+    // Open the ARCropolis menu if ZR or Minus is held before mod discovery 
+    if ninput::any::is_down(ninput::Buttons::MINUS) || ninput::any::is_down(ninput::Buttons::ZR) {
         crate::menus::show_main_menu();
-    }
+    } 
 
     let filter = |path: &Path| {
         // If we're not running on emulator


### PR DESCRIPTION
Official Smash GCN adapter controllers do not have the minus button or plus button. I thought ZR was a good addition for this reason, as someone in the HDR server asked about this