### PR TITLE
arc:/ regional implementation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -110,12 +110,8 @@ lazy_static! {
     };
 
     static ref REGION: Region = {
-        const REGIONS: &[&str] = &[
-            "jp_ja", "us_en", "us_fr", "us_es", "eu_en", "eu_fr", "eu_es", "eu_de", "eu_nl", "eu_it",
-            "eu_ru", "kr_ko", "zh_cn", "zh_tw",
-        ];
 
-        Region::from(REGIONS.iter().position(|&x| {
+        Region::from(crate::REGIONS.iter().position(|&x| {
             x == &region_str()
         }).map(|x| (x + 1) as u32).unwrap_or(0))
     };

--- a/src/fuse/arc.rs
+++ b/src/fuse/arc.rs
@@ -65,8 +65,8 @@ impl FileSystemAccessor for ArcFuse {
         for region in REGIONS.iter() {
             if path.file_name().unwrap().to_string_lossy().contains(region) {
                 let mut new_path = path.display().to_string();
-                let region_string = format!("+{}", region);
-                new_path.remove_matches(region_string);
+                let mut region_string = format!("+{}", region);
+                new_path.remove_matches(&region_string);
                 file_region = Region::from_str(region).unwrap();
                 let path = std::path::Path::new(&new_path);
             }

--- a/src/fuse/arc.rs
+++ b/src/fuse/arc.rs
@@ -1,7 +1,8 @@
 use std::io::Write;
+use std::str::FromStr;
 
 use nn_fuse::{AccessorResult, DAccessor, DirectoryAccessor, FAccessor, FileAccessor, FileSystemAccessor, FsAccessor, FsEntryType};
-use smash_arc::{ArcFile, ArcLookup, Hash40};
+use smash_arc::{ArcFile, ArcLookup, Hash40, Region};
 
 use crate::PathExtension;
 
@@ -9,19 +10,19 @@ lazy_static! {
     static ref ARC_FILE: ArcFile = { ArcFile::open("rom:/data.arc").unwrap() };
 }
 
-pub struct ArcFileAccessor(Hash40);
+pub struct ArcFileAccessor(Hash40, Region);
 
 impl FileAccessor for ArcFileAccessor {
     fn read(&mut self, mut buffer: &mut [u8], offset: usize) -> Result<usize, AccessorResult> {
         debug!("ArcFileAccessor::read - Buffer length: {:x}", buffer.len());
-        let file = ARC_FILE.get_file_contents(self.0, smash_arc::Region::UsEnglish).unwrap();
+        let file = ARC_FILE.get_file_contents(self.0, self.1).unwrap();
         Ok(buffer.write(&file.as_slice()[offset..]).unwrap())
     }
 
     fn get_size(&mut self) -> Result<usize, AccessorResult> {
         debug!("ArcFileAccessor::get_size");
         Ok(ARC_FILE
-            .get_file_data_from_hash(self.0, smash_arc::Region::UsEnglish)
+            .get_file_data_from_hash(self.0, self.1)
             .unwrap()
             .decomp_size as _)
     }
@@ -55,14 +56,29 @@ impl FileSystemAccessor for ArcFuse {
         let read = mode >> 0 & 1;
         let write = mode >> 1 & 1;
         let append = mode >> 2 & 1;
-
+        const REGIONS: &[&str] = &[
+            "jp_ja", "us_en", "us_fr", "us_es", "eu_en", "eu_fr", "eu_es", "eu_de", "eu_nl", "eu_it",
+            "eu_ru", "kr_ko", "zh_cn", "zh_tw",
+        ];
         debug!("Path: {}, read: {}, write: {}, append: {}", path.display(), read, write, append);
+        let mut file_region = Region::UsEnglish;
+        for region in REGIONS.iter() {
+            if path.file_name().unwrap().to_string_lossy().contains(region) {
+                let mut new_path = path.display().to_string();
+                let region_string = format!("+{}", region);
+                new_path.remove_matches(region_string);
+                file_region = Region::from_str(region).unwrap();
+                let path = std::path::Path::new(&new_path);
+            }
+        }
 
         let hash = path.smash_hash().unwrap();
-
+        if !ARC_FILE.get_file_info_from_hash(hash).unwrap().flags.is_regional() {
+            file_region = Region::None;
+        }
         if read != 0 {
             if ARC_FILE.get_file_path_index_from_hash(hash).is_ok() {
-                Ok(FAccessor::new(ArcFileAccessor(hash), mode))
+                Ok(FAccessor::new(ArcFileAccessor(hash, file_region), mode))
             } else {
                 Err(AccessorResult::PathNotFound)
             }

--- a/src/fuse/arc.rs
+++ b/src/fuse/arc.rs
@@ -61,7 +61,7 @@ impl FileSystemAccessor for ArcFuse {
             "eu_ru", "kr_ko", "zh_cn", "zh_tw",
         ];
         debug!("Path: {}, read: {}, write: {}, append: {}", path.display(), read, write, append);
-        let mut file_region = Region::UsEnglish;
+        let mut file_region = crate::config::region();
         for region in REGIONS.iter() {
             if path.file_name().unwrap().to_string_lossy().contains(region) {
                 let mut new_path = path.display().to_string();

--- a/src/fuse/arc.rs
+++ b/src/fuse/arc.rs
@@ -56,15 +56,11 @@ impl FileSystemAccessor for ArcFuse {
         let read = mode >> 0 & 1;
         let write = mode >> 1 & 1;
         let append = mode >> 2 & 1;
-        const REGIONS: &[&str] = &[
-            "jp_ja", "us_en", "us_fr", "us_es", "eu_en", "eu_fr", "eu_es", "eu_de", "eu_nl", "eu_it",
-            "eu_ru", "kr_ko", "zh_cn", "zh_tw",
-        ];
         debug!("Path: {}, read: {}, write: {}, append: {}", path.display(), read, write, append);
         let mut file_region = crate::config::region();
-        for region in REGIONS.iter() {
-            if path.file_name().unwrap().to_string_lossy().contains(region) {
-                let mut new_path = path.display().to_string();
+        let mut new_path = path.display().to_string();
+        for region in crate::REGIONS.iter() {
+            if new_path.contains(region) {
                 let mut region_string = format!("+{}", region);
                 new_path.remove_matches(&region_string);
                 file_region = Region::from_str(region).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,10 @@ fn get_path_from_hash(hash: Hash40) -> PathBuf {
     }
 }
 
+pub const REGIONS: &[&str] = &[
+    "jp_ja", "us_en", "us_fr", "us_es", "eu_en", "eu_fr", "eu_es", "eu_de", "eu_nl", "eu_it",
+    "eu_ru", "kr_ko", "zh_cn", "zh_tw",
+];
 /// Initializes the `nn::time` library, for creating a log file based off of the current time. For some reason Smash does not initialize this
 fn init_time() {
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(map_try_insert)] // for not overwriting previously stored hashes
 #![feature(vec_into_raw_parts)]
 #![allow(unaligned_references)]
+#![feature(string_remove_matches)]
 #![feature(allocator_api)]
 
 use std::{


### PR DESCRIPTION
Let the user get regional files by their regional variant through the arc:/ mount point.


closes #329

draft until https://github.com/jam1garner/smash-arc/pull/10 gets merged