### PR TITLE
fix the infinite loading

### DIFF
--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -89,7 +89,7 @@ pub extern "C" fn arcrop_is_mod_enabled(hash: Hash40) -> bool {
                 if let Ok(entry) = entry {
                     // Make this less gross
                     if !entry.file_type().is_dir() {
-                        return None
+                        return None;
                     }
 
                     let path = entry.path();

--- a/src/chainloader.rs
+++ b/src/chainloader.rs
@@ -78,7 +78,7 @@ impl NrrBuilder {
     pub fn register(self) -> Result<Option<RegistrationInfo>, NrrRegistrationFailedError> {
         let Self { hashes: mut module_hashes } = self;
         if module_hashes.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
         module_hashes.sort();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,20 +159,20 @@ fn convert_legacy_to_presets() -> HashSet<Hash40> {
     if umm_path().exists() {
         // TODO: Turn this into a map and use Collect
         for entry in WalkDir::new(umm_path()).max_depth(1).into_iter().flatten() {
-                let path = entry.path();
+            let path = entry.path();
 
-                // If the mod isn't disabled, add it to the preset
-                if path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .map(|name| !name.starts_with('.'))
-                    .unwrap_or(false)
-                {
-                    presets.insert(Hash40::from(path.to_str().unwrap()));
-                } else {
-                    // TODO: Check if the destination already exists, because it'll definitely happen, and when someone opens an issue about it and you'll realize you knew ahead of time, you'll feel dumb. But right this moment, you decided not to do anything.
-                    std::fs::rename(path, format!("sd:/ultimate/mods/{}", &path.file_name().unwrap().to_str().unwrap()[1..])).unwrap();
-                }
+            // If the mod isn't disabled, add it to the preset
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| !name.starts_with('.'))
+                .unwrap_or(false)
+            {
+                presets.insert(Hash40::from(path.to_str().unwrap()));
+            } else {
+                // TODO: Check if the destination already exists, because it'll definitely happen, and when someone opens an issue about it and you'll realize you knew ahead of time, you'll feel dumb. But right this moment, you decided not to do anything.
+                std::fs::rename(path, format!("sd:/ultimate/mods/{}", &path.file_name().unwrap().to_str().unwrap()[1..])).unwrap();
+            }
         }
     }
 
@@ -261,7 +261,11 @@ pub fn region() -> Region {
 }
 
 pub fn region_str() -> String {
-    let region: String = GLOBAL_CONFIG.lock().unwrap().get_field("region").unwrap_or_else(|_| String::from("us_en"));
+    let region: String = GLOBAL_CONFIG
+        .lock()
+        .unwrap()
+        .get_field("region")
+        .unwrap_or_else(|_| String::from("us_en"));
     region
 }
 
@@ -284,7 +288,11 @@ pub fn extra_paths() -> Vec<String> {
 }
 
 pub fn logger_level() -> String {
-    let level: String = GLOBAL_CONFIG.lock().unwrap().get_field("logging_level").unwrap_or_else(|_| String::from("Warn"));
+    let level: String = GLOBAL_CONFIG
+        .lock()
+        .unwrap()
+        .get_field("logging_level")
+        .unwrap_or_else(|_| String::from("Warn"));
     level
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -59,12 +59,12 @@ impl CachedFilesystem {
             let full_path = root.join(local);
             if !full_path.exists() {
                 warn!("Collected path at {} does not exist.", full_path.display());
-                continue
+                continue;
             }
 
             if !full_path.ends_with("config.json") {
                 trace!("Skipping path {} while loading all configs", full_path.display());
-                continue
+                continue;
             }
 
             // Read the file data and map it to a json. If that fails, just skip this current JSON.
@@ -243,7 +243,7 @@ impl CachedFilesystem {
                     hash.0,
                     size.green()
                 );
-                return None
+                return None;
             },
         };
 
@@ -286,7 +286,7 @@ impl CachedFilesystem {
                 hashes::find(hash),
                 hash.0
             );
-            return None
+            return None;
         };
 
         match self.loader.load(path) {
@@ -406,16 +406,16 @@ impl CachedFilesystem {
         // Go through and add any files that were not found in the data.arc
         self.loader.walk_patch(|node, ty| {
             if node.get_local().is_stream() || !ty.is_file() {
-                return
+                return;
             }
 
             let _hash = if let Ok(hash) = node.get_local().smash_hash() {
                 if context.contains_file(hash) {
-                    return
+                    return;
                 }
                 hash
             } else {
-                return
+                return;
             };
 
             replacement::addition::add_file(&mut context, node.get_local());
@@ -499,11 +499,9 @@ impl GlobalFilesystem {
     pub fn finish(self, _arc: &'static LoadedArc) -> Result<Self, FilesystemUninitializedError> {
         match self {
             Self::Uninitialized => Err(FilesystemUninitializedError),
-            Self::Promised(promise) => {
-                match promise.join() {
-                    Ok(launchpad) => Ok(Self::Initialized(Box::new(CachedFilesystem::make_from_promise(launchpad)))),
-                    Err(_) => Err(FilesystemUninitializedError),
-                }
+            Self::Promised(promise) => match promise.join() {
+                Ok(launchpad) => Ok(Self::Initialized(Box::new(CachedFilesystem::make_from_promise(launchpad)))),
+                Err(_) => Err(FilesystemUninitializedError),
             },
             Self::Initialized(filesystem) => Ok(Self::Initialized(filesystem)),
         }
@@ -653,7 +651,9 @@ impl GlobalFilesystem {
 
     pub fn handle_api_request(&mut self, call: api::PendingApiCall) {
         debug!("Incoming API request");
-        if let Self::Initialized(fs) = self { fs.handle_late_api_call(call) }
+        if let Self::Initialized(fs) = self {
+            fs.handle_late_api_call(call)
+        }
     }
 
     pub fn get_cached_size(&self, hash: Hash40) -> Option<usize> {

--- a/src/fs/discover.rs
+++ b/src/fs/discover.rs
@@ -245,33 +245,32 @@ pub fn perform_discovery() -> LaunchPad<StandardLoader> {
 
         for conflict in conflicts.into_iter() {
             if let ConflictKind::StandardConflict {
-                    error_root,
-                    local,
-                    source_root,
-                } = conflict {
-                    if let Some(conflicting_mods) = conflict_map.get_mut(&local) {
-                        conflicting_mods.push(error_root);
-                    } else {
-                        conflict_map.insert(local, vec![source_root, error_root]);
-                    }
+                error_root,
+                local,
+                source_root,
+            } = conflict
+            {
+                if let Some(conflicting_mods) = conflict_map.get_mut(&local) {
+                    conflicting_mods.push(error_root);
+                } else {
+                    conflict_map.insert(local, vec![source_root, error_root]);
                 }
+            }
         }
 
         let should_log = match serde_json::to_string_pretty(&conflict_map) {
-            Ok(json) => {
-                match std::fs::write("sd:/ultimate/arcropolis/conflicts.json", json.as_bytes()) {
-                    Ok(_) => {
-                        crate::dialog_error("Please check sd:/ultimate/arcropolis/conflicts.json for all of the file conflicts.");
-                        false
-                    },
-                    Err(e) => {
-                        crate::dialog_error(format!(
-                            "Failed to write conflict map to sd:/ultimate/arcropolis/conflicts.json<br>{:?}",
-                            e
-                        ));
-                        true
-                    },
-                }
+            Ok(json) => match std::fs::write("sd:/ultimate/arcropolis/conflicts.json", json.as_bytes()) {
+                Ok(_) => {
+                    crate::dialog_error("Please check sd:/ultimate/arcropolis/conflicts.json for all of the file conflicts.");
+                    false
+                },
+                Err(e) => {
+                    crate::dialog_error(format!(
+                        "Failed to write conflict map to sd:/ultimate/arcropolis/conflicts.json<br>{:?}",
+                        e
+                    ));
+                    true
+                },
             },
             Err(e) => {
                 crate::dialog_error(format!("Failed to serialize conflict map to JSON. {:?}", e));
@@ -312,16 +311,14 @@ where
     let fighter_nro_parent = Path::new("prebuilt;/nro/release");
     let mut fighter_nro_nrr = NrrBuilder::new();
 
-    tree.walk_paths(|node, entry_type| {
-        match node.get_local().parent() {
-            Some(parent) if entry_type.is_file() && parent == fighter_nro_parent => {
-                info!("Reading '{}' for module registration.", node.full_path().display());
-                if let Ok(data) = std::fs::read(node.full_path()) {
-                    fighter_nro_nrr.add_module(data.as_slice());
-                }
-            },
-            _ => {},
-        }
+    tree.walk_paths(|node, entry_type| match node.get_local().parent() {
+        Some(parent) if entry_type.is_file() && parent == fighter_nro_parent => {
+            info!("Reading '{}' for module registration.", node.full_path().display());
+            if let Ok(data) = std::fs::read(node.full_path()) {
+                fighter_nro_nrr.add_module(data.as_slice());
+            }
+        },
+        _ => {},
     });
 
     fighter_nro_nrr.register()
@@ -359,7 +356,7 @@ pub fn load_and_run_plugins(plugins: &[(PathBuf, PathBuf)]) {
 
     if modules.is_empty() {
         info!("No plugins found for chainloading.");
-        return
+        return;
     }
 
     let mut registration_info = match plugin_nrr.register() {
@@ -368,7 +365,7 @@ pub fn load_and_run_plugins(plugins: &[(PathBuf, PathBuf)]) {
         Err(e) => {
             error!("{:?}", e);
             crate::dialog_error("ARCropolis failed to register plugin module info.");
-            return
+            return;
         },
     };
 
@@ -378,14 +375,12 @@ pub fn load_and_run_plugins(plugins: &[(PathBuf, PathBuf)]) {
     // i didn't write hos
     let modules: Vec<Module> = modules
         .into_iter()
-        .filter_map(|x| {
-            match x.mount() {
-                Ok(module) => Some(module),
-                Err(e) => {
-                    error!("Failed to mount chainloaded plugin. {:?}", e);
-                    None
-                },
-            }
+        .filter_map(|x| match x.mount() {
+            Ok(module) => Some(module),
+            Err(e) => {
+                error!("Failed to mount chainloaded plugin. {:?}", e);
+                None
+            },
         })
         .collect();
 

--- a/src/fs/discover.rs
+++ b/src/fs/discover.rs
@@ -372,7 +372,11 @@ pub fn load_and_run_plugins(plugins: &[(PathBuf, PathBuf)]) {
         },
     };
 
-    let modules = modules
+    // we have to do it this way
+    // i'm sorry ray, but it literally does not work without collecting here
+    // i don't know
+    // i didn't write hos
+    let modules: Vec<Module> = modules
         .into_iter()
         .filter_map(|x| {
             match x.mount() {
@@ -382,7 +386,8 @@ pub fn load_and_run_plugins(plugins: &[(PathBuf, PathBuf)]) {
                     None
                 },
             }
-        });
+        })
+        .collect();
 
     unsafe {
         // Unfortunately, without unregistering this it will cause the game to crash, cause is unknown, but likely due to page alignment I'd guess

--- a/src/fs/loaders.rs
+++ b/src/fs/loaders.rs
@@ -378,18 +378,16 @@ impl ApiLoader {
     fn get_stream_cb_path(&self, local: &Path) -> Option<String> {
         if let Some((root_path, callback)) = self.use_virtual_file(local) {
             let result = match ApiLoadType::from_root(root_path) {
-                Ok(ApiLoadType::Stream) => {
-                    match ApiLoadType::Stream.load_path(local, callback) {
-                        Ok((sz, data)) => unsafe {
-                            if let Some(prev_size) = (*self.stream_size_map.get()).get_mut(local) {
-                                *prev_size = sz;
-                            } else {
-                                (*self.stream_size_map.get()).insert(local.to_path_buf(), sz);
-                            }
-                            Some(skyline::from_c_str(data.as_ptr()))
-                        },
-                        _ => self.get_stream_cb_path(local),
-                    }
+                Ok(ApiLoadType::Stream) => match ApiLoadType::Stream.load_path(local, callback) {
+                    Ok((sz, data)) => unsafe {
+                        if let Some(prev_size) = (*self.stream_size_map.get()).get_mut(local) {
+                            *prev_size = sz;
+                        } else {
+                            (*self.stream_size_map.get()).insert(local.to_path_buf(), sz);
+                        }
+                        Some(skyline::from_c_str(data.as_ptr()))
+                    },
+                    _ => self.get_stream_cb_path(local),
                 },
                 _ => self.get_stream_cb_path(local),
             };
@@ -417,7 +415,7 @@ impl FileLoader for ApiLoader {
 
     fn get_file_size(&self, _root_path: &Path, local_path: &Path) -> Option<usize> {
         if let Some(sz) = unsafe { (*self.stream_size_map.get()).get(local_path) } {
-            return Some(*sz)
+            return Some(*sz);
         }
         if let Some((root_path, _)) = self.use_virtual_file(local_path) {
             let result = ApiLoadType::from_root(root_path)
@@ -451,10 +449,9 @@ impl FileLoader for ApiLoader {
     fn load_path(&self, _root_path: &Path, local_path: &Path) -> Result<Vec<u8>, Self::ErrorType> {
         if let Some((root_path, callback)) = self.use_virtual_file(local_path) {
             let result = match ApiLoadType::from_root(root_path) {
-                Ok(ty) => {
-                    ty.load_path(local_path, callback)
-                        .map_or_else(|_| self.load_path(root_path, local_path), |(_, data)| Ok(data))
-                },
+                Ok(ty) => ty
+                    .load_path(local_path, callback)
+                    .map_or_else(|_| self.load_path(root_path, local_path), |(_, data)| Ok(data)),
                 Err(e) => Err(e),
             };
             self.release_virtual_file(local_path);
@@ -499,21 +496,18 @@ impl FileLoader for ArcLoader {
 
     fn get_file_size(&self, _: &Path, local_path: &Path) -> Option<usize> {
         match crate::get_smash_hash(local_path) {
-            Ok(hash) => {
-                self.get_file_data_from_hash(hash, config::region())
-                    .map_or_else(|_| None, |data| Some(data.decomp_size as usize))
-            },
+            Ok(hash) => self
+                .get_file_data_from_hash(hash, config::region())
+                .map_or_else(|_| None, |data| Some(data.decomp_size as usize)),
             Err(_) => None,
         }
     }
 
     fn get_path_type(&self, _: &Path, local_path: &Path) -> Result<FileEntryType, Self::ErrorType> {
         match crate::get_smash_hash(local_path) {
-            Ok(hash) => {
-                match self.get_path_list_entry_from_hash(hash)?.is_directory() {
-                    true => Ok(FileEntryType::Directory),
-                    false => Ok(FileEntryType::File),
-                }
+            Ok(hash) => match self.get_path_list_entry_from_hash(hash)?.is_directory() {
+                true => Ok(FileEntryType::Directory),
+                false => Ok(FileEntryType::File),
             },
             _ => Err(LookupError::Missing),
         }

--- a/src/fs/utils.rs
+++ b/src/fs/utils.rs
@@ -28,14 +28,14 @@ where
     let mut path_map = HashMap::new();
     tree.walk_paths(|node, ty| {
         if !ty.is_file() {
-            return
+            return;
         }
 
         if let Some(size) = tree.query_filesize(node.get_local()) {
             match node.get_local().smash_hash() {
                 Ok(hash) => {
                     if regional_overrides.contains(&hash) {
-                        return
+                        return;
                     }
 
                     let is_regional_variant = if let Some(node) = node.get_local().to_str() { node.contains('+') } else { false };
@@ -65,12 +65,12 @@ where
     let mut nus3banks_found = HashSet::new();
     tree.walk_paths(|node, ty| {
         if !ty.is_file() {
-            return
+            return;
         }
 
         let local = node.get_local();
         if local.is_stream() {
-            return
+            return;
         }
 
         if local.has_extension("nus3audio") {

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -17,7 +17,7 @@ static HASHES: Lazy<RwLock<HashMap<Hash40, &'static str>>> = Lazy::new(|| {
                 "Failed to read '{}' for hashes. Reason: {:?}. There won't be any hash lookups in this run's logs.",
                 HASH_FILEPATH, e
             );
-            return RwLock::new(hashes)
+            return RwLock::new(hashes);
         },
         Ok(s) => s,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@ use arcropolis_api::Event;
 use log::LevelFilter;
 use thiserror::Error;
 
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 use once_cell::sync::Lazy;
 use parking_lot::{const_rwlock, RwLock};
@@ -35,7 +36,8 @@ mod menus;
 mod offsets;
 mod replacement;
 mod resource;
-#[cfg(feature = "updater")] mod update;
+#[cfg(feature = "updater")]
+mod update;
 
 use fs::GlobalFilesystem;
 use smash_arc::Hash40;
@@ -133,7 +135,7 @@ impl PathExtension for Path {
                 )
                 .map(Hash40);
             if let Some(hash) = hash {
-                return Ok(hash)
+                return Ok(hash);
             }
         }
         let mut path = self
@@ -294,20 +296,18 @@ pub fn main() {
     let mut filesystem = GLOBAL_FILESYSTEM.write();
 
     let discovery = std::thread::Builder::new()
-    .stack_size(0x40000)
-    .spawn(|| {
-        unsafe {
-            let curr_thread = nn::os::GetCurrentThread();
-            nn::os::ChangeThreadPriority(curr_thread, 0);
-        }
-        std::thread::sleep(std::time::Duration::from_millis(5000));
-        fs::perform_discovery()
-    })
-    .unwrap();
+        .stack_size(0x40000)
+        .spawn(|| {
+            unsafe {
+                let curr_thread = nn::os::GetCurrentThread();
+                nn::os::ChangeThreadPriority(curr_thread, 0);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5000));
+            fs::perform_discovery()
+        })
+        .unwrap();
 
-    *filesystem = GlobalFilesystem::Promised(
-        discovery
-    );
+    *filesystem = GlobalFilesystem::Promised(discovery);
 
     let resources = std::thread::Builder::new()
         .stack_size(0x40000)
@@ -329,21 +329,21 @@ pub fn main() {
                 }
 
                 if config::auto_update_enabled() {
-                        update::check_for_updates(config::beta_updates(), |update_kind| {
-                            // skyline_web::Dialog::yes_no(format!(
-                            //     "{} has been detected. Do you want to install it?",
-                            //     update_kind
-                            // ))
+                    update::check_for_updates(config::beta_updates(), |update_kind| {
+                        // skyline_web::Dialog::yes_no(format!(
+                        //     "{} has been detected. Do you want to install it?",
+                        //     update_kind
+                        // ))
 
-                            // This didn't compile
-                            skyline_web::Dialog::no_yes(format!("{} has been detected. Do you want to install it?", update_kind))
+                        // This didn't compile
+                        skyline_web::Dialog::no_yes(format!("{} has been detected. Do you want to install it?", update_kind))
 
-                            // match skyline_web::Dialog::yes_no(format!("{} has been detected. Do you want to install it?", update_kind)) {
-                            //     true => true,
-                            //     false => false,
-                            // }
-                        });
-                    }
+                        // match skyline_web::Dialog::yes_no(format!("{} has been detected. Do you want to install it?", update_kind)) {
+                        //     true => true,
+                        //     false => false,
+                        // }
+                    });
+                }
             })
             .unwrap();
     }
@@ -356,11 +356,9 @@ pub fn main() {
 
         let msg = match info.payload().downcast_ref::<&'static str>() {
             Some(s) => *s,
-            None => {
-                match info.payload().downcast_ref::<String>() {
-                    Some(s) => &s[..],
-                    None => "Box<Any>",
-                }
+            None => match info.payload().downcast_ref::<String>() {
+                Some(s) => &s[..],
+                None => "Box<Any>",
             },
         };
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -16,9 +16,10 @@ use crate::config;
 fn format_time_string(seconds: u64) -> String {
     let leapyear = |year| -> bool { year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) };
 
-    static YEAR_TABLE: [[u64; 12]; 2] = [[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31], [
-        31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
-    ]];
+    static YEAR_TABLE: [[u64; 12]; 2] = [
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    ];
 
     let mut year = 1970;
 
@@ -35,7 +36,7 @@ fn format_time_string(seconds: u64) -> String {
             day_number -= year_length;
             year += 1;
         } else {
-            break
+            break;
         }
     }
     let mut month = 0;
@@ -108,7 +109,7 @@ impl log::Log for ArcLogger {
 
     fn log(&self, record: &Record) {
         if !self.enabled(record.metadata()) {
-            return
+            return;
         }
 
         let module_path = match record.module_path() {

--- a/src/menus/arcadia/mod.rs
+++ b/src/menus/arcadia/mod.rs
@@ -46,7 +46,7 @@ pub fn get_mods(presets: &HashSet<Hash40>) -> Vec<Entry> {
             let path_to_be_used = path.unwrap().path();
 
             if path_to_be_used.is_file() {
-                return None
+                return None;
             }
 
             let disabled = !presets.contains(&Hash40::from(path_to_be_used.to_str().unwrap()));
@@ -66,23 +66,21 @@ pub fn get_mods(presets: &HashSet<Hash40>) -> Vec<Entry> {
             };
 
             let mod_info = match toml::from_str::<Entry>(&std::fs::read_to_string(&info_path).unwrap_or_default()) {
-                Ok(res) => {
-                    Entry {
-                        id: Some(id),
-                        folder_name: Some(folder_name.clone()),
-                        display_name: res.display_name.or(Some(folder_name)),
-                        authors: res.authors.or_else(|| Some(String::from("???"))),
-                        is_disabled: Some(disabled),
-                        version: res.version.or_else(|| Some(String::from("???"))),
-                        category: res.category.map_or(Some(String::from("Misc")), |cat| {
-                            if cat == "Music" {
-                                Some("Audio".to_string())
-                            } else {
-                                Some(cat)
-                            }
-                        }),
-                        description: Some(res.description.unwrap_or_default().replace('\n', "<br />")),
-                    }
+                Ok(res) => Entry {
+                    id: Some(id),
+                    folder_name: Some(folder_name.clone()),
+                    display_name: res.display_name.or(Some(folder_name)),
+                    authors: res.authors.or_else(|| Some(String::from("???"))),
+                    is_disabled: Some(disabled),
+                    version: res.version.or_else(|| Some(String::from("???"))),
+                    category: res.category.map_or(Some(String::from("Misc")), |cat| {
+                        if cat == "Music" {
+                            Some("Audio".to_string())
+                        } else {
+                            Some(cat)
+                        }
+                    }),
+                    description: Some(res.description.unwrap_or_default().replace('\n', "<br />")),
                 },
                 Err(e) => {
                     skyline_web::DialogOk::ok(&format!("The following info.toml is not valid: \n\n* '{}'\n\nError: {}", folder_name, e,));
@@ -102,7 +100,7 @@ pub fn show_arcadia(workspace: Option<String>) {
 
     if !umm_path.exists() {
         skyline_web::DialogOk::ok("It seems the directory specified in your configuration does not exist.");
-        return
+        return;
     }
 
     let mut storage = config::GLOBAL_CONFIG.lock().unwrap();
@@ -201,7 +199,7 @@ pub fn show_arcadia(workspace: Option<String>) {
             ArcadiaMessage::Closure => {
                 session.exit();
                 session.wait_for_exit();
-                break
+                break;
             },
         }
     }

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -26,19 +26,17 @@ pub fn show_main_menu() {
 
     match response.get_last_url().unwrap() {
         "http://localhost/" => {},
-        url => {
-            match url {
-                "http://localhost/arcadia" => {
-                    show_arcadia(None);
-                },
-                "http://localhost/workspaces" => {
-                    show_workspaces();
-                },
-                "http://localhost/config" => {
-                    show_config_editor(&mut crate::config::GLOBAL_CONFIG.lock().unwrap());
-                },
-                _ => {},
-            }
+        url => match url {
+            "http://localhost/arcadia" => {
+                show_arcadia(None);
+            },
+            "http://localhost/workspaces" => {
+                show_workspaces();
+            },
+            "http://localhost/config" => {
+                show_config_editor(&mut crate::config::GLOBAL_CONFIG.lock().unwrap());
+            },
+            _ => {},
         },
     }
 }

--- a/src/menus/workspaces/mod.rs
+++ b/src/menus/workspaces/mod.rs
@@ -64,7 +64,7 @@ pub fn show_workspaces() {
                 session.exit();
                 storage.set_field_json("workspace_list", &workspace_list).unwrap_or_default();
                 workspace_to_edit = Some(name);
-                break
+                break;
             },
             WorkspacesMessage::Rename { source_name, target_name } => {
                 let preset_name = workspace_list[&source_name].clone();
@@ -90,7 +90,7 @@ pub fn show_workspaces() {
                 session.wait_for_exit();
                 session.exit();
                 storage.set_field_json("workspace_list", &workspace_list).unwrap_or_default();
-                break
+                break;
             },
         }
     }

--- a/src/offsets.rs
+++ b/src/offsets.rs
@@ -5,14 +5,12 @@ use skyline::hooks::{getRegionAddress, Region};
 static OFFSETS: Lazy<Offsets> = Lazy::new(|| {
     let path = crate::CACHE_PATH.join("offsets.toml");
     let offsets = match std::fs::read_to_string(&path) {
-        Ok(string) => {
-            match toml::de::from_str(string.as_str()) {
-                Ok(offsets) => offsets,
-                Err(err) => {
-                    error!("Unable to parse 'offsets.toml'. Reason: {:?}", err);
-                    Offsets::new()
-                },
-            }
+        Ok(string) => match toml::de::from_str(string.as_str()) {
+            Ok(offsets) => offsets,
+            Err(err) => {
+                error!("Unable to parse 'offsets.toml'. Reason: {:?}", err);
+                Offsets::new()
+            },
         },
         Err(err) => {
             error!("Unable to read 'offsets.toml'. Reason: {:?}", err);

--- a/src/replacement/addition.rs
+++ b/src/replacement/addition.rs
@@ -3,7 +3,12 @@ use std::{collections::HashSet, path::Path};
 use smash_arc::*;
 
 use super::{lookup, AdditionContext, FromPathExt, SearchContext};
-use crate::{hashes, replacement::FileInfoFlagsExt, resource::{LoadedFilepath, LoadedData}, PathExtension};
+use crate::{
+    hashes,
+    replacement::FileInfoFlagsExt,
+    resource::{LoadedData, LoadedFilepath},
+    PathExtension,
+};
 
 pub fn add_file(ctx: &mut AdditionContext, path: &Path) {
     // Create a FilePath from the path that's passed in
@@ -11,7 +16,7 @@ pub fn add_file(ctx: &mut AdditionContext, path: &Path) {
         file_path
     } else {
         error!("Failed to generate a FilePath from {}!", path.display());
-        return
+        return;
     };
 
     // Create a new FilePathIdx by getting the length of all filepaths in the vector
@@ -32,7 +37,7 @@ pub fn add_file(ctx: &mut AdditionContext, path: &Path) {
         Region::None,
     );
 
-    // Create a new FileInfoIndex with the created file_info_idx above and a dir offset index of 
+    // Create a new FileInfoIndex with the created file_info_idx above and a dir offset index of
     let new_info_indice_idx = FileInfoIndex {
         dir_offset_index: 0xFF_FFFF,
         file_info_index: file_info_idx,
@@ -99,7 +104,7 @@ pub fn add_shared_file(ctx: &mut AdditionContext, path: &Path, shared_to: Hash40
                 hashes::find(shared_to),
                 shared_to.0
             );
-            return
+            return;
         },
     };
 
@@ -108,7 +113,7 @@ pub fn add_shared_file(ctx: &mut AdditionContext, path: &Path, shared_to: Hash40
         Some(filepath) => filepath,
         None => {
             error!("Failed to convert path '{}' to FilePath struct!", path.display());
-            return
+            return;
         },
     };
 
@@ -136,40 +141,38 @@ pub fn add_searchable_folder_recursive(ctx: &mut SearchContext, path: &Path) {
                 ctx.path_list_indices.push(ctx.paths.len() as u32);
                 ctx.paths.push(new_path);
                 ctx.folder_paths.push(new_folder_path);
-                return
+                return;
             } else {
                 error!("Unable to generate new folder path list entry for {}", path.display());
-                return
+                return;
             }
         },
-        Some(parent) => {
-            match parent.smash_hash() {
-                Ok(hash) => {
-                    let len = ctx.path_list_indices.len();
-                    match ctx.get_folder_path_mut(hash) {
-                        Some(parent) => (parent, len),
-                        None => {
-                            add_searchable_folder_recursive(ctx, parent);
-                            let len = ctx.path_list_indices.len();
-                            match ctx.get_folder_path_mut(hash) {
-                                Some(parent) => (parent, len),
-                                None => {
-                                    error!("Unable to add folder '{}'", parent.display());
-                                    return
-                                },
-                            }
-                        },
-                    }
-                },
-                Err(e) => {
-                    error!("Unable to get the smash hash for '{}'. {:?}", parent.display(), e);
-                    return
-                },
-            }
+        Some(parent) => match parent.smash_hash() {
+            Ok(hash) => {
+                let len = ctx.path_list_indices.len();
+                match ctx.get_folder_path_mut(hash) {
+                    Some(parent) => (parent, len),
+                    None => {
+                        add_searchable_folder_recursive(ctx, parent);
+                        let len = ctx.path_list_indices.len();
+                        match ctx.get_folder_path_mut(hash) {
+                            Some(parent) => (parent, len),
+                            None => {
+                                error!("Unable to add folder '{}'", parent.display());
+                                return;
+                            },
+                        }
+                    },
+                }
+            },
+            Err(e) => {
+                error!("Unable to get the smash hash for '{}'. {:?}", parent.display(), e);
+                return;
+            },
         },
         None => {
             error!("Failed to get the parent for path '{}'", path.display());
-            return
+            return;
         },
     };
 
@@ -198,7 +201,7 @@ pub fn add_searchable_file_recursive(ctx: &mut SearchContext, path: &Path) {
         // If the parent is empty, then just return
         Some(parent) if parent == Path::new("") => {
             error!("Cannot add file {} as root file!", path.display());
-            return
+            return;
         },
         // Else if the parent is alright (actually something), keep going
         Some(parent) => {
@@ -225,7 +228,7 @@ pub fn add_searchable_file_recursive(ctx: &mut SearchContext, path: &Path) {
                                 // Else, just return
                                 None => {
                                     error!("Unable to add folder '{}'", parent.display());
-                                    return
+                                    return;
                                 },
                             }
                         },
@@ -233,13 +236,13 @@ pub fn add_searchable_file_recursive(ctx: &mut SearchContext, path: &Path) {
                 },
                 Err(e) => {
                     error!("Unable to get the smash hash for '{}'. {:?}", parent.display(), e);
-                    return
+                    return;
                 },
             }
         },
         None => {
             error!("Failed to get the parent for path '{}'", path.display());
-            return
+            return;
         },
     };
 
@@ -278,7 +281,7 @@ pub fn add_files_to_directory(ctx: &mut AdditionContext, directory: Hash40, file
         Ok(dir) => dir.file_info_range(),
         Err(_) => {
             error!("Cannot get file info range for '{}' ({:#x})", hashes::find(directory), directory.0);
-            return
+            return;
         },
     };
 
@@ -292,13 +295,11 @@ pub fn add_files_to_directory(ctx: &mut AdditionContext, directory: Hash40, file
     for file_info in ctx.file_infos[file_info_range.clone()].iter() {
         // Insert directory file hash40 to the contained files set
         contained_files.insert(ctx.filepaths[usize::from(file_info.file_path_index)].path.hash40());
-        
+
         // If the file_info_range has an entry for the FileInfoIndex for the current file, then update the FileInfoIdx
         // with a new FileInfoIdx that takes the context file_infos length + the length of the current file_infos (don't know why this is done)
         if file_info_range.contains(&usize::from(
-            ctx.file_info_indices[
-                ctx.filepaths[usize::from(file_info.file_path_index)].path.index() as usize
-            ].file_info_index,
+            ctx.file_info_indices[ctx.filepaths[usize::from(file_info.file_path_index)].path.index() as usize].file_info_index,
         )) {
             ctx.file_info_indices[ctx.filepaths[usize::from(file_info.file_path_index)].path.index() as usize].file_info_index =
                 FileInfoIdx((ctx.file_infos.len() + file_infos.len()) as u32);
@@ -311,28 +312,26 @@ pub fn add_files_to_directory(ctx: &mut AdditionContext, directory: Hash40, file
     for file in files {
         // If the file passed in is already exists, then just skip it
         if contained_files.contains(&file) {
-            continue
+            continue;
         }
 
         // Get the FilePathIdx from the context
         if let Some(file_index) = get_path_idx(ctx, file) {
-            
             // Get the FileInfoToData from the InfoToData array context
             let info_to_data = &mut ctx.info_to_datas[usize::from(
-                ctx.file_infos[
-                    usize::from(ctx.file_info_indices[ctx.filepaths[usize::from(file_index)].path.index() as usize
-                    ].file_info_index)].info_to_data_index,
+                ctx.file_infos[usize::from(ctx.file_info_indices[ctx.filepaths[usize::from(file_index)].path.index() as usize].file_info_index)]
+                    .info_to_data_index,
             )];
-            
+
             // Set the folder offset index to 0
             info_to_data.folder_offset_index = 0x0;
-            
+
             // Get the data index from the info -> data
             let data_idx = info_to_data.file_data_index;
-            
+
             // Get the FileData from the FileDatas with the FileDataIdx gotten earlier
             let file_data = &mut ctx.file_datas[usize::from(data_idx)];
-            
+
             // Set the compressed and decompressed size to 0x100 (256) (The decompressed size will change later
             // when patched by ARCropolis)
             file_data.comp_size = 0x100;
@@ -343,24 +342,17 @@ pub fn add_files_to_directory(ctx: &mut AdditionContext, directory: Hash40, file
 
             // Set the flags to not be compressed and not use zstd
             file_data.flags = FileDataFlags::new().with_compressed(false).with_use_zstd(false);
-            
+
             // Get the FileInfo from the context FileInfos with the FileInfoIndex with the file_index gotten
-            // earlier 
+            // earlier
             let file_info =
-                ctx.file_infos[
-                    usize::from(
-                        ctx.file_info_indices[
-                            ctx.filepaths[
-                                usize::from(file_index)
-                            ].path.index() as usize
-                        ].file_info_index)
-                    ];
+                ctx.file_infos[usize::from(ctx.file_info_indices[ctx.filepaths[usize::from(file_index)].path.index() as usize].file_info_index)];
 
             // Set the file info index to the current context file infos size + the current length of the
             // file_infos vector created earlier
             ctx.file_info_indices[ctx.filepaths[usize::from(file_index)].path.index() as usize].file_info_index =
                 FileInfoIdx((ctx.file_infos.len() + file_infos.len()) as u32);
-            
+
             // Push the modified file_info to the file_infos vector
             file_infos.push(file_info);
         } else {
@@ -379,7 +371,7 @@ pub fn add_files_to_directory(ctx: &mut AdditionContext, directory: Hash40, file
     let dir_info = ctx
         .get_dir_info_from_hash_mut(directory)
         .expect("Failed to get directory after confirming it exists");
-    
+
     // Modify the directory start index and the file count
     dir_info.file_info_start_index = start_index;
     dir_info.file_count = file_infos.len() as u32;

--- a/src/replacement/addition.rs
+++ b/src/replacement/addition.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, path::Path};
 use smash_arc::*;
 
 use super::{lookup, AdditionContext, FromPathExt, SearchContext};
-use crate::{hashes, replacement::FileInfoFlagsExt, resource::LoadedFilepath, PathExtension};
+use crate::{hashes, replacement::FileInfoFlagsExt, resource::{LoadedFilepath, LoadedData}, PathExtension};
 
 pub fn add_file(ctx: &mut AdditionContext, path: &Path) {
     // Create a FilePath from the path that's passed in
@@ -81,7 +81,7 @@ pub fn add_file(ctx: &mut AdditionContext, path: &Path) {
 
     // Push default values to the loaded_(filepaths/datas) to make it match up with the other vectors length
     ctx.loaded_filepaths.push(LoadedFilepath::default());
-    ctx.loaded_datas.reserve(1);
+    ctx.loaded_datas.push(LoadedData::new());
 
     // Insert the added FilePath's path and it's index to the context's added_files vector
     ctx.added_files.insert(file_path.path.hash40(), filepath_idx);

--- a/src/replacement/extensions.rs
+++ b/src/replacement/extensions.rs
@@ -180,12 +180,7 @@ impl LoadedArcEx for LoadedArc {
         let file_datas = CppVector::from_slice(arc.get_file_datas());
 
         let loaded_filepaths = CppVector::from_slice(filesystem_info.get_loaded_filepaths());
-        let loaded_datas = unsafe {
-            let loaded_datas = filesystem_info.get_loaded_datas();
-            let mut vec = CppVector::with_capacity(loaded_datas.len());
-            std::ptr::copy_nonoverlapping(loaded_datas.as_ptr(), vec.as_mut_ptr(), loaded_datas.len());
-            vec
-        };
+        let loaded_datas = CppVector::clone_from_slice(filesystem_info.get_loaded_datas());
 
         AdditionContext {
             arc,
@@ -221,8 +216,8 @@ impl LoadedArcEx for LoadedArc {
         let (file_infos, file_info_len) = (file_infos.as_mut_ptr(), file_infos.len());
         let (info_to_datas, info_to_data_len) = (info_to_datas.as_mut_ptr(), info_to_datas.len());
         let (file_datas, file_data_len) = (file_datas.as_mut_ptr(), file_datas.len());
-        let (loaded_filepaths, _) = (loaded_filepaths.as_mut_ptr(), loaded_filepaths.len());
-        let (loaded_datas, _) = (loaded_datas.as_mut_ptr(), loaded_datas.len());
+        let (loaded_filepaths, loaded_filepath_len) = (loaded_filepaths.as_mut_ptr(), loaded_filepaths.len());
+        let (loaded_datas, loaded_data_len) = (loaded_datas.as_mut_ptr(), loaded_datas.len());
 
         let header = unsafe { &mut *(self.fs_header as *mut FileSystemHeader) };
 
@@ -244,10 +239,10 @@ impl LoadedArcEx for LoadedArc {
         let fs_info = resource::filesystem_info_mut();
 
         fs_info.loaded_filepaths = loaded_filepaths;
-        fs_info.loaded_filepath_len = filepath_len as u32;
+        fs_info.loaded_filepath_len = loaded_filepath_len as u32;
 
         fs_info.loaded_datas = loaded_datas;
-        fs_info.loaded_data_len = info_index_len as u32;
+        fs_info.loaded_data_len = loaded_data_len as u32;
 
         self.resort_file_hashes();
     }

--- a/src/replacement/extensions.rs
+++ b/src/replacement/extensions.rs
@@ -86,11 +86,9 @@ impl SearchContext {
     pub fn get_folder_path_mut(&mut self, hash: Hash40) -> Option<&mut FolderPathListEntry> {
         match self.search.get_folder_path_index_from_hash(hash) {
             Ok(entry) => Some(&mut self.folder_paths[entry.index() as usize]),
-            Err(_) => {
-                match self.new_folder_paths.get(&hash) {
-                    Some(index) => Some(&mut self.folder_paths[*index]),
-                    None => None,
-                }
+            Err(_) => match self.new_folder_paths.get(&hash) {
+                Some(index) => Some(&mut self.folder_paths[*index]),
+                None => None,
             },
         }
     }
@@ -360,7 +358,7 @@ pub trait SearchEx: SearchLookup {
         let index_idx = folder_path.get_first_child_index();
 
         if index_idx == 0xFF_FFFF {
-            return Err(LookupError::Missing)
+            return Err(LookupError::Missing);
         }
 
         let path_entry_index = self.get_path_list_indices()[index_idx];
@@ -374,7 +372,7 @@ pub trait SearchEx: SearchLookup {
     fn get_next_child_in_folder_mut(&mut self, current_child: &PathListEntry) -> Result<&mut PathListEntry, LookupError> {
         let index_idx = current_child.path.index() as usize;
         if index_idx == 0xFF_FFFF {
-            return Err(LookupError::Missing)
+            return Err(LookupError::Missing);
         }
 
         let path_entry_index = self.get_path_list_indices()[index_idx];
@@ -579,11 +577,9 @@ impl FromPathExt for FilePath {
         };
 
         let ext_hash = match path.extension().and_then(|x| x.to_str()) {
-            Some(str) => {
-                match get_smash_hash(str) {
-                    Ok(hash) => hash,
-                    Err(_) => return None,
-                }
+            Some(str) => match get_smash_hash(str) {
+                Ok(hash) => hash,
+                Err(_) => return None,
             },
             None => return None,
         };
@@ -672,11 +668,9 @@ impl FromPathExt for PathListEntry {
         };
 
         let ext_hash = match path.extension().and_then(|x| x.to_str()) {
-            Some(str) => {
-                match get_smash_hash(str) {
-                    Ok(hash) => hash,
-                    Err(_) => return None,
-                }
+            Some(str) => match get_smash_hash(str) {
+                Ok(hash) => hash,
+                Err(_) => return None,
             },
             None => return None,
         };

--- a/src/replacement/lookup.rs
+++ b/src/replacement/lookup.rs
@@ -48,18 +48,16 @@ enum ShareLookupState {
 static UNSHARE_LOOKUP: Lazy<RwLock<UnshareLookupState>> = Lazy::new(|| {
     let path = crate::CACHE_PATH.join("unshare.lut");
     let lut = match std::fs::read(&path) {
-        Ok(data) => {
-            match bincode::deserialize(&data) {
-                Ok(lut) => UnshareLookupState::Generated(lut),
-                Err(e) => {
-                    error!(
-                        "Unable to parse '{}' for unsharing. Reason: {:?}. Boot time might be a bit slow.",
-                        path.display(),
-                        *e
-                    );
-                    UnshareLookupState::Missing
-                },
-            }
+        Ok(data) => match bincode::deserialize(&data) {
+            Ok(lut) => UnshareLookupState::Generated(lut),
+            Err(e) => {
+                error!(
+                    "Unable to parse '{}' for unsharing. Reason: {:?}. Boot time might be a bit slow.",
+                    path.display(),
+                    *e
+                );
+                UnshareLookupState::Missing
+            },
         },
         Err(err) => {
             error!("Unable to read '{}'. Reason: {:?}", path.display(), err);
@@ -73,18 +71,16 @@ static UNSHARE_LOOKUP: Lazy<RwLock<UnshareLookupState>> = Lazy::new(|| {
 static SHARE_LOOKUP: Lazy<RwLock<ShareLookupState>> = Lazy::new(|| {
     let path = crate::CACHE_PATH.join("share.lut");
     let lut = match std::fs::read(&path) {
-        Ok(data) => {
-            match bincode::deserialize(&data) {
-                Ok(lut) => ShareLookupState::Generated(lut),
-                Err(e) => {
-                    error!(
-                        "Unable to parse '{}' for share lookup. Reason: {:?}. Boot time might be a bit slow.",
-                        path.display(),
-                        *e
-                    );
-                    ShareLookupState::Missing
-                },
-            }
+        Ok(data) => match bincode::deserialize(&data) {
+            Ok(lut) => ShareLookupState::Generated(lut),
+            Err(e) => {
+                error!(
+                    "Unable to parse '{}' for share lookup. Reason: {:?}. Boot time might be a bit slow.",
+                    path.display(),
+                    *e
+                );
+                ShareLookupState::Missing
+            },
         },
         Err(err) => {
             error!("Unable to read '{}'. Reason: {:?}", path.display(), err);
@@ -98,7 +94,7 @@ static SHARE_LOOKUP: Lazy<RwLock<ShareLookupState>> = Lazy::new(|| {
 pub fn initialize_unshare(arc: Option<&LoadedArc>) {
     if arc.is_none() {
         Lazy::force(&UNSHARE_LOOKUP);
-        return
+        return;
     }
     let arc = arc.unwrap();
     let mut lookup_state = UNSHARE_LOOKUP.write();
@@ -136,7 +132,7 @@ pub fn initialize_unshare(arc: Option<&LoadedArc>) {
 pub fn initialize_share(arc: Option<&LoadedArc>) {
     if arc.is_none() {
         Lazy::force(&SHARE_LOOKUP);
-        return
+        return;
     }
 
     let arc = arc.unwrap();
@@ -155,7 +151,7 @@ pub fn initialize_share(arc: Option<&LoadedArc>) {
                 let shared_file_index = match arc.get_shared_file(hash) {
                     Ok(idx) => {
                         if usize::from(idx) == current_index {
-                            continue
+                            continue;
                         }
                         idx
                     },
@@ -165,7 +161,7 @@ pub fn initialize_share(arc: Option<&LoadedArc>) {
                             hashes::find(hash),
                             hash.0
                         );
-                        continue
+                        continue;
                     },
                 };
 
@@ -264,11 +260,10 @@ pub fn get_shared_file_count<H: Into<Hash40>>(hash: H) -> usize {
 pub fn get_shared_file<H: Into<Hash40>>(hash: H, index: usize) -> Option<Hash40> {
     let lut = SHARE_LOOKUP.read();
     match &*lut {
-        ShareLookupState::Generated(lut) => {
-            lut.shared_file_lookup
-                .get(&hash.into())
-                .map_or_else(|| None, |hashes| hashes.get(index).copied())
-        },
+        ShareLookupState::Generated(lut) => lut
+            .shared_file_lookup
+            .get(&hash.into())
+            .map_or_else(|| None, |hashes| hashes.get(index).copied()),
         _ => None,
     }
 }

--- a/src/replacement/preprocess.rs
+++ b/src/replacement/preprocess.rs
@@ -14,7 +14,7 @@ pub fn reshare_contained_files(ctx: &mut AdditionContext, dependent: Hash40, sou
                 hashes::find(source),
                 source.0
             );
-            return HashSet::new()
+            return HashSet::new();
         },
     };
 
@@ -26,7 +26,7 @@ pub fn reshare_contained_files(ctx: &mut AdditionContext, dependent: Hash40, sou
                 hashes::find(dependent),
                 dependent.0
             );
-            return HashSet::new()
+            return HashSet::new();
         },
     };
 

--- a/src/replacement/stream.rs
+++ b/src/replacement/stream.rs
@@ -20,15 +20,15 @@ fn lookup_stream_hash(out_path: *mut c_char, loaded_arc: &LoadedArc, size_out: &
                 let cpath = format!("{}\0", path.display());
                 let out_buffer = unsafe { std::slice::from_raw_parts_mut(out_path, cpath.len()) };
                 out_buffer.copy_from_slice(cpath.as_bytes());
-                return
+                return;
             } else if path.exists() {
                 if let Ok(size) = std::fs::metadata(&path).map(|x| x.len()) {
-                        *size_out = size as usize;
-                        *offset_out = 0;
-                        let cpath = format!("{}\0", path.display());
-                        let out_buffer = unsafe { std::slice::from_raw_parts_mut(out_path, cpath.len()) };
-                        out_buffer.copy_from_slice(cpath.as_bytes());
-                        return
+                    *size_out = size as usize;
+                    *offset_out = 0;
+                    let cpath = format!("{}\0", path.display());
+                    let out_buffer = unsafe { std::slice::from_raw_parts_mut(out_path, cpath.len()) };
+                    out_buffer.copy_from_slice(cpath.as_bytes());
+                    return;
                 }
             }
         }

--- a/src/replacement/threads.rs
+++ b/src/replacement/threads.rs
@@ -75,7 +75,7 @@ pub fn handle_file_replace(hash: Hash40) {
         Ok(info) => info,
         Err(_) => {
             error!("Failed to find file info for '{}' ({:#x}) when replacing.", hashes::find(hash), hash.0);
-            return
+            return;
         },
     };
 
@@ -102,7 +102,7 @@ pub fn handle_file_replace(hash: Hash40) {
             filepath_index,
             file_info_indice_index
         );
-        return
+        return;
     }
 
     let mut fs = crate::GLOBAL_FILESYSTEM.write();

--- a/src/replacement/unshare.rs
+++ b/src/replacement/unshare.rs
@@ -6,7 +6,7 @@ use smash_arc::*;
 use super::{extensions::*, lookup};
 use crate::{
     config, hashes,
-    resource::{self, LoadedFilepath},
+    resource::{self, LoadedFilepath, LoadedData},
 };
 
 pub static SHARED_FILE_INDEX: Lazy<u32> = Lazy::new(|| resource::arc().get_shared_data_index());
@@ -170,7 +170,7 @@ fn reshare_dependent_files(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash
     // Funnily enough, we have to actually push on LoadedFilepaths, because just allocating space for it is bad as it won't clear the data if there
     // are zero references
     ctx.loaded_filepaths.push(LoadedFilepath::default());
-    ctx.loaded_datas.reserve(1);
+    ctx.loaded_datas.push(LoadedData::new());
 }
 
 fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: Hash40) {
@@ -347,7 +347,7 @@ fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: 
         .set_index(new_info_indice_idx.0);
 
     // we only need to reserve memory here, since none of these are active
-    ctx.loaded_datas.reserve(1);
+    ctx.loaded_datas.push(LoadedData::new());
 
     // The reasoning for this is that there is something called "source" files, which is basically the only file in the
     // shared file chain that contains the actual data. For example, let's say that Marth's source file for his model's `model.numdlb`

--- a/src/replacement/unshare.rs
+++ b/src/replacement/unshare.rs
@@ -6,7 +6,7 @@ use smash_arc::*;
 use super::{extensions::*, lookup};
 use crate::{
     config, hashes,
-    resource::{self, LoadedFilepath, LoadedData},
+    resource::{self, LoadedData, LoadedFilepath},
 };
 
 pub static SHARED_FILE_INDEX: Lazy<u32> = Lazy::new(|| resource::arc().get_shared_data_index());
@@ -25,7 +25,7 @@ fn reshare_dependent_files(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash
                 hashes::find(hash),
                 hash.0
             );
-            return
+            return;
         },
     };
 
@@ -40,7 +40,7 @@ fn reshare_dependent_files(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash
             hashes::find(hash),
             hash.0
         );
-        return
+        return;
     }
 
     // Here we set the length to 255, because no path in the game even comes close to that long we should be fine.
@@ -114,7 +114,7 @@ fn reshare_dependent_files(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash
         // Don't worry about files in our ignore list
         // If this seems confusing, note that the `hash_ignore` comes from files that we do our preprocessing on (i.e. Dark Samus models for victory screen)
         if hash_ignore.contains(&dependent_hash) {
-            continue
+            continue;
         }
         // Get the DirInfo and the child index of the dependent hash, if it doesn't exist... then just move on to the next one ig
         let (dir_hash, child_idx) = match lookup::get_dir_entry_for_file(dependent_hash) {
@@ -127,7 +127,7 @@ fn reshare_dependent_files(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash
                     hashes::find(hash),
                     hash.0
                 );
-                continue
+                continue;
             },
         };
 
@@ -142,7 +142,7 @@ fn reshare_dependent_files(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash
                     hashes::find(hash),
                     hash.0
                 );
-                continue
+                continue;
             },
         };
 
@@ -176,13 +176,13 @@ fn reshare_dependent_files(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash
 fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: Hash40) {
     // Ignore the provided hash if it is contained in our list of ignored files
     if hash_ignore.contains(&hash) {
-        return
+        return;
     }
 
     // Check if the file is stored in our lookup table (the `is_shared_search` field)
     if !lookup::is_shared_file(hash) {
         trace!("File '{}' ({:#x}) did not need to be unshared.", hashes::find(hash), hash.0);
-        return
+        return;
     }
 
     // Get the shared file path index from the LoadedArc
@@ -198,7 +198,7 @@ fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: 
                 hashes::find(hash),
                 hash.0
             );
-            return
+            return;
         },
     };
 
@@ -211,7 +211,7 @@ fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: 
                 hashes::find(hash),
                 hash.0
             );
-            return
+            return;
         },
     };
 
@@ -224,7 +224,7 @@ fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: 
                 hashes::find(hash),
                 hash.0
             );
-            return
+            return;
         },
     };
 
@@ -238,7 +238,7 @@ fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: 
                 [usize::from(ctx.file_info_indices[ctx.filepaths[usize::from(current_path_index)].path.index() as usize].file_info_index)];
             file_info.flags.set_standalone_file(true);
             if ctx.arc.get_file_in_folder(file_info, config::region()).file_data_index.0 < *SHARED_FILE_INDEX {
-                return
+                return;
             }
         },
         Ok(_) => {},
@@ -248,7 +248,7 @@ fn unshare_file(ctx: &mut AdditionContext, hash_ignore: &HashSet<Hash40>, hash: 
                 hashes::find(hash),
                 hash.0
             );
-            return
+            return;
         },
     }
 
@@ -394,7 +394,7 @@ fn reshare_file_group(ctx: &mut AdditionContext, dir_info: Range<usize>, file_gr
                 && !file_group.contains(&usize::from(shared_idx))
                 && !referenced_file_infos.contains(&shared_idx))
         {
-            continue
+            continue;
         }
 
         ctx.file_infos[usize::from(dir_index)].flags.set_standalone_file(true);

--- a/src/resource/containers.rs
+++ b/src/resource/containers.rs
@@ -206,7 +206,7 @@ impl<'a, T> Iterator for CppVectorIterator<'a, T> {
         unsafe {
             if self.vector.start.offset(self.index) != self.vector.end {
                 self.index += 1;
-                Some(&* self.vector.start.offset(self.index - 1))
+                Some(&*self.vector.start.offset(self.index - 1))
             } else {
                 None
             }

--- a/src/resource/containers.rs
+++ b/src/resource/containers.rs
@@ -135,6 +135,19 @@ impl<T: Copy + Clone> CppVector<T> {
     }
 }
 
+impl<T: Clone> CppVector<T> {
+    pub fn clone_from_slice(slice: &[T]) -> Self {
+        let layout = Layout::from_size_align(slice.len() * std::mem::size_of::<T>(), 1).unwrap();
+        let (start, eos) = unsafe {
+            let start = std::alloc::alloc(layout) as *mut T;
+            (start, start.add(slice.len()))
+        };
+        let new_slice = unsafe { std::slice::from_raw_parts_mut(start, slice.len()) };
+        new_slice.clone_from_slice(slice);
+        Self { start, end: eos, eos }
+    }
+}
+
 impl<T> Index<usize> for CppVector<T> {
     type Output = T;
 

--- a/src/resource/types.rs
+++ b/src/resource/types.rs
@@ -47,7 +47,7 @@ impl LoadedData {
             file_flags2: false,
             flags: 0,
             version: 0,
-            unk: 0
+            unk: 0,
         }
     }
 }
@@ -62,8 +62,8 @@ impl Clone for LoadedData {
             file_flags2: self.file_flags2,
             flags: self.flags,
             version: self.version,
-            unk: self.unk
-        }    
+            unk: self.unk,
+        }
     }
 }
 

--- a/src/resource/types.rs
+++ b/src/resource/types.rs
@@ -1,6 +1,6 @@
 use std::{
     ops::{Index, IndexMut},
-    sync::atomic::AtomicU32,
+    sync::atomic::{AtomicU32, Ordering},
 };
 
 use skyline::nn;
@@ -35,6 +35,36 @@ pub struct LoadedData {
     pub flags: u8,
     pub version: u32,
     pub unk: u8,
+}
+
+impl LoadedData {
+    pub fn new() -> Self {
+        Self {
+            data: std::ptr::null(),
+            ref_count: AtomicU32::new(0),
+            is_used: false,
+            state: LoadState::Unloaded,
+            file_flags2: false,
+            flags: 0,
+            version: 0,
+            unk: 0
+        }
+    }
+}
+
+impl Clone for LoadedData {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data,
+            ref_count: AtomicU32::new(self.ref_count.load(Ordering::SeqCst)),
+            is_used: self.is_used,
+            state: self.state,
+            file_flags2: self.file_flags2,
+            flags: self.flags,
+            version: self.version,
+            unk: self.unk
+        }    
+    }
 }
 
 #[derive(Debug)]

--- a/src/update.rs
+++ b/src/update.rs
@@ -49,7 +49,7 @@ where
         Ok(r) => r,
         Err(e) => {
             error!("Failed to check for updates: {:?}", e);
-            return
+            return;
         },
     };
 
@@ -63,7 +63,7 @@ where
     let release = match (prerelease_tag, release_tag) {
         (None, None) => {
             error!("No github releases were found!");
-            return
+            return;
         },
         (prerelease_tag, release_tag) => {
             if prerelease_tag > release_tag {
@@ -79,20 +79,20 @@ where
         Ok(diff) => diff,
         Err(e) => {
             error!("Failed to parse version strings: {:?}", e);
-            return
+            return;
         },
     };
 
     if let Some(update_kind) = version_difference {
         if !f(update_kind) {
-            return
+            return;
         }
         if let Some(release) = release.get_asset_by_name("release.zip") {
             let mut zip = match ZipArchive::new(std::io::Cursor::new(release)) {
                 Ok(zip) => zip,
                 Err(e) => {
                     error!("Failed to parse zip data: {:?}", e);
-                    return
+                    return;
                 },
             };
 


### PR DESCRIPTION
Changes the behavior when "reserving" memory for the `LoadedData` table to initialize all fields to `0`. (also fixes the chainloader because writing good rust makes it not work because the switch operating system is held together by runny glue and chalky tape)

go to infinite loading jail
![image](https://user-images.githubusercontent.com/42755519/173007261-db6da0d6-f59d-4c01-b3e7-50d631d6e403.png)


![image](https://user-images.githubusercontent.com/42755519/173006748-5cda14b7-afc2-49be-b340-d1b065ae6a2e.png)
![image](https://user-images.githubusercontent.com/42755519/173007035-7dcf9049-a73f-40e7-ba7e-3e4e7dfefe15.png)
