### PR TITLE
Patch motion_list.bin files on discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ serde-xml-rs = "0.6"
 msbt = { git = "https://github.com/RoccoDev/msbt-rs", branch = "feature/builder-from-impl" }
 # For patch3audio
 nus3audio = "1.2.0"
+# For motion list patching
+motion_list_rs = { git = "https://github.com/WuBoytH/motion_lib", branch = "motion-lib-only" }
+serde_yaml = "0.8"
 # For inputs
 ninput = { git = "https://github.com/blu-dev/ninput" }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -128,6 +128,20 @@ impl CachedFilesystem {
         set
     }
 
+    /// Get a list of all motion list patch files and add them to the virtual tree
+    fn initialize_motionlist_patches(launchpad: &LaunchPad<StandardLoader>, api_tree: &mut Tree<ApiLoader>) -> HashSet<Hash40> {
+        let mut set = HashSet::new();
+        for (root, path) in launchpad.collected_paths().iter() {
+            // The collected paths gives us everything so we only want these extensions
+            if path.has_extension("motdiff") {
+                if let Some(hash) = utils::add_motionlist_patch(api_tree, root, path) {
+                    set.insert(hash);
+                }
+            }
+        }
+        set
+    }
+
     /// Parse a pending API call and add it to the API tree. This function returns the hash, as well as the size (if needed)
     /// so that the caller can insert those into the global structs depending on the time that this call is handled
     fn handle_panding_api_call(api_tree: &mut Tree<ApiLoader>, pending: api::PendingApiCall) -> ApiCallResult {
@@ -195,6 +209,7 @@ impl CachedFilesystem {
         let mut hashes = Self::initialize_prc_patches(&launchpad, &mut api_tree);
         hashes.extend(Self::initialize_msbt_patches(&launchpad, &mut api_tree));
         hashes.extend(Self::initialize_nus3audio_patches(&launchpad, &mut api_tree));
+        hashes.extend(Self::initialize_motionlist_patches(&launchpad, &mut api_tree));
 
         // Add the hash files and set the new size to 10x the original files
         for hash in hashes {

--- a/src/fs/discover.rs
+++ b/src/fs/discover.rs
@@ -77,7 +77,9 @@ pub fn perform_discovery() -> LaunchPad<StandardLoader> {
 
                     "xmsbt",
 
-                    "patch3audio"
+                    "patch3audio",
+
+                    "motdiff"
                 ];
                 RESERVED_NAMES.contains(&name) || {
                     let is_out_of_region = if let Some(index) = name.find('+') {

--- a/src/fs/loaders.rs
+++ b/src/fs/loaders.rs
@@ -305,41 +305,18 @@ impl ApiLoadType {
 
                 let data = ApiLoader::handle_load_base_file(local)?;
 
-                // let mut param_data = prcx::read_stream(&mut std::io::Cursor::new(data))
-                //     .map_err(|_| ApiLoaderError::Other("Unable to parse param data!".to_string()))?;
-
-                // for patch_path in patches.iter() {
-                //     let patch = if let Ok(patch) = prcx::open(patch_path) {
-                //         patch
-                //     } else {
-                //         let file = std::fs::File::open(patch_path)?;
-                //         let mut reader = std::io::BufReader::new(file);
-                //         prcx::read_xml(&mut reader).map_err(|_| ApiLoaderError::Other("Unable to parse param patch data!".to_string()))?
-                //     };
-                //     prcx::apply_patch(&patch, &mut param_data).map_err(|_| ApiLoaderError::Other("Unable to patch param data!".to_string()))?;
-                // }
-
-                // let mut cursor = std::io::Cursor::new(vec![]);
-                // prcx::write_stream(&mut cursor, &param_data)?;
-                // let vec = cursor.into_inner();
-                // Ok((vec.len(), vec))
-                // let motion = motion_lib::open(local).unwrap();
                 let mut motion = motion_lib::disasm::disassemble(&mut std::io::Cursor::new(data))?;
+
                 for patch_path in patches.iter() {
-                    // if let Ok(patch) = std::fs::File::open(patch_path) {
-                        let mut contents: String = String::default();
-                        std::fs::File::open(patch_path)?.read_to_string(&mut contents)?;
-                        if let Some(diff) = from_str(&contents)? {
-                            println!("[ARCropolis::loader] Patching Motion List");
-                            motion.apply(&diff);
-                        }
-                        else {
-                            return Err(ApiLoaderError::Other("This isn't a motion list patch file!".to_string()));
-                        }
-                    // } else {
-                    //     return Err(ApiLoaderError::Other("This isn't a motion list patch file!".to_string()));
-                    // }
-                    // prcx::apply_patch(&patch, &mut param_data).map_err(|_| ApiLoaderError::Other("Unable to patch param data!".to_string()))?;
+                    let mut contents: String = String::default();
+                    std::fs::File::open(patch_path)?.read_to_string(&mut contents)?;
+                    if let Some(diff) = from_str(&contents)? {
+                        println!("[ARCropolis::loader] Patching Motion List");
+                        motion.apply(&diff);
+                    }
+                    else {
+                        return Err(ApiLoaderError::Other("This isn't a motion list patch file!".to_string()));
+                    }
                 }
                 let new_data : Vec<u8> = Vec::new();
                 let mut cursor = std::io::Cursor::new(new_data);

--- a/src/fs/utils.rs
+++ b/src/fs/utils.rs
@@ -234,3 +234,46 @@ pub fn add_nus3audio_patch<P: AsRef<Path>, Q: AsRef<Path>>(tree: &mut Tree<ApiLo
         },
     }
 }
+
+pub fn add_motionlist_patch<P: AsRef<Path>, Q: AsRef<Path>>(tree: &mut Tree<ApiLoader>, phys_root: P, local: Q) -> Option<Hash40> {
+    let local = local.as_ref();
+    let base_local = local.with_extension("bin");
+
+    let base_local = if let Some(name) = base_local.file_name().and_then(|os_str| os_str.to_str()) {
+        if let Some(idx) = name.find('+') {
+            let mut new_name = name.to_string();
+            new_name.replace_range(idx..idx + 6, "");
+            base_local.with_file_name(new_name)
+        } else {
+            base_local
+        }
+    } else {
+        base_local
+    };
+    let full_path = phys_root.as_ref().join(local); // need the full path so that our API loader can load it
+    if let Some(name) = full_path.file_name() {
+        if name.to_str().unwrap().contains(&"motion_list") {
+            match base_local.smash_hash() {
+                Ok(hash) => {
+                    tree.insert_file("api:/patch-motionlist", &base_local);
+                    tree.loader.push_entry(hash, Path::new("api:/patch-motionlist"), ApiCallback::None);
+                    // We need to add our file to the vector of patch files
+                    tree.loader.insert_motionlist_patch(hash, &full_path);
+                    if let Some(local) = local.to_str() {
+                        hashes::add(local);
+                    }
+                    if let Some(base_local) = base_local.to_str() {
+                        hashes::add(base_local);
+                    }
+                    return Some(hash);
+                },
+                Err(e) => {
+                    error!("Could not add file {} to API tree. Reason: {:?}", full_path.display(), e);
+                    return None;
+                },
+            }
+        }
+    }
+    error!("Could not add file {} to API tree. Reason: This is not a motion_list.bin file.", full_path.display());
+    None
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(unaligned_references)]
 #![feature(string_remove_matches)]
 #![feature(let_else)]
-#![feature(fs_try_exists)]
+// #![feature(fs_try_exists)]
 
 use std::{
     collections::HashMap,


### PR DESCRIPTION
You can generate a motion_list.motdiff file using `yamlist diff [source file] [modded file] -o motion_list.motdiff`. Then you can place it where a `motion_list.bin` file would normally go, and it will patch it on runtime.