### PR TITLE
(fixes/offsets) [comfort feature] Allow for loading uncompiled lua script files.

### DIFF
--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -1,5 +1,5 @@
 use skyline::{hook, hooks::InlineCtx, install_hooks, from_offset, patching::Patch};
-use crate::offsets::offset_to_addr;
+use crate::offsets::*;
 
 // OFFSETS IN THIS FILE ARE CURRENTLY HARDCODED TO VERSION 13.0.1
 
@@ -205,7 +205,13 @@ fn install_lazy_loading_patches(){
     install_hooks!(original_load_chara_1_ui_for_all_colors, css_set_selected_chararacter_ui, load_stock_icon_for_portrait_menu, chara_select_scene_destructor);
 }
 
+// Patch to allow running uncompiled lua scripts
+fn install_lua_magic_patch() {
+	Patch::in_text(lua_magic_check()).nop().expect("Failed to patch lua magic check cbnz");
+}
+
 pub fn install() {
     install_added_color_patches();
     install_lazy_loading_patches();
+    install_lua_magic_patch();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,8 @@ impl PathExtension for Path {
             .map_or(Err(InvalidOsStrError), Ok)?
             .to_lowercase()
             .replace(';', ":")
-            .replace(".mp4", ".webm");
+            .replace(".mp4", ".webm")
+            .replace(".lua", ".lc");
 
         if let Some(regional_idx) = path.find('+') {
             path.replace_range(regional_idx..regional_idx + 6, "")

--- a/src/offsets.rs
+++ b/src/offsets.rs
@@ -95,6 +95,10 @@ static PACKET_SEND_SEARCH_CODE: &[u8] = &[
     0x28, 0x4c, 0x43, 0xb9, 0x08, 0x4c, 0x03, 0xb9, 0xc0, 0x03, 0x5f, 0xd6, 0x00, 0x00, 0x00, 0x00,
 ];
 
+static LUA_MAGIC_CHECK_SEARCH_CODE: &[u8] = &[
+    0xfd, 0x7b, 0x04, 0xa9, 0xfd, 0x03, 0x01, 0x91, 0x08, 0x04, 0x40, 0xf9, 0x93, 0x00, 0x80, 0x52, 0x13, 0x00, 0xa8, 0x72,
+];
+
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|window| window == needle)
 }
@@ -153,6 +157,8 @@ struct Offsets {
     pub res_service: usize,
 
     pub packet_send: usize,
+	
+    pub lua_magic_check: usize,
 }
 
 impl Offsets {
@@ -172,7 +178,8 @@ impl Offsets {
         let title_screen_version = find_subsequence(text, TITLE_SCREEN_VERSION_SEARCH_CODE).expect("Unable to find subsequence!");
         let eshop_button = find_subsequence(text, ESHOPMANAGER_SHOW_SEARCH_CODE).expect("Unable to find subsequence!") - 16;
         let packet_send = find_subsequence(text, PACKET_SEND_SEARCH_CODE).expect("Unable to find subsequence!") + 16;
-
+        let lua_magic_check = find_subsequence(text, LUA_MAGIC_CHECK_SEARCH_CODE).expect("Unable to find subsequence!") + 176;
+		
         let filesystem_info = {
             let adrp = find_subsequence(text, FILESYSTEM_INFO_ADRP_SEARCH_CODE).expect("Unable to find subsequence") + 12;
             let adrp_offset = offset_from_adrp(adrp);
@@ -201,7 +208,8 @@ impl Offsets {
             title_screen_version,
             eshop_button,
             packet_send,
-
+			lua_magic_check,
+			
             filesystem_info,
             res_service,
         }
@@ -262,4 +270,8 @@ pub fn lookup_stream_hash() -> usize {
 
 pub fn packet_send() -> usize {
     OFFSETS.packet_send
+}
+
+pub fn lua_magic_check() -> usize {
+    OFFSETS.lua_magic_check
 }


### PR DESCRIPTION
Adds a quick ``nop`` patch over a ``cbnz`` instruction that makes the function responsible for loading loose ``.lc`` files return early, so uncompiled Lua source files can be used in-game. The offset for the patch is in ``offsets.rs``, while the actual code patch lives in ``fixes.rs``. The ``.lua`` extension gets swapped out with ``.lc`` in ``lib.rs``, akin to the way mp4 support is implemented in master.