### PR TITLE
Default Region to Us English when no save exists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod fixes;
 use fs::GlobalFilesystem;
 use smash_arc::{Hash40, Region};
 
-use crate::{config::{GLOBAL_CONFIG, REGION}, utils::save::{get_language_id_in_savedata, get_system_region_from_language_id, mount_save, unmount_save}, resource::res_service};
+use crate::{config::{GLOBAL_CONFIG, REGION}, utils::save::{get_language_id_in_savedata, get_system_region_from_language_id, mount_save, unmount_save}};
 
 pub static GLOBAL_FILESYSTEM: RwLock<GlobalFilesystem> = const_rwlock(GlobalFilesystem::Uninitialized);
 
@@ -380,23 +380,7 @@ pub fn main() {
         // Default to UsEnglish if there is no Save Data on this boot
         match language_id {
             Ok(id) => *region = get_system_region_from_language_id(id),
-            Err(e) => {
-                // How do we want to match on different kinds of errors? Have another match here? Add another arm to the match?
-                if e.to_string() == "Result code: 514" {
-                    // Handle no Save Data FS Read Error
-                    /*unsafe {
-                        *region = Region::from(res_service().region_idx); // TODO: Remove
-                    }*/
-                    *region = Region::UsEnglish
-                } else {
-                    // TODO: How do we want to handle other FS Read errors on Save Data?
-                    skyline::error::show_error(
-                        70,
-                        "Unknown Save Data Error.\n\0",
-                        "L + Ratio",
-                    );
-                }
-            }
+            Err(_) => *region = Region::UsEnglish,
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -81,7 +81,7 @@ pub mod paths {
 
 pub mod save {
     use super::*;
-    use std::io::{Read, Seek, SeekFrom};
+    use std::io::{Read, Seek, SeekFrom, Result};
     use smash_arc::Region;
 
     #[repr(u8)]
@@ -138,14 +138,14 @@ pub mod save {
         unsafe { nn::fs::Unmount(skyline::c_str(&format!("{}\0", mount_path))) };
     }
 
-    pub fn get_language_id_in_savedata() -> SaveLanguageId {
-        let mut file = std::fs::File::open("save:/save_data/system_data.bin").unwrap();
+    pub fn get_language_id_in_savedata() -> Result<SaveLanguageId> {
+        let mut file = std::fs::File::open("save:/save_data/system_data.bin")?;
         file.seek(SeekFrom::Start(0x3c6098)).unwrap();
         let mut language_code = [0u8];
         file.read_exact(&mut language_code).unwrap();
         drop(file);
 
-        SaveLanguageId::from(language_code[0])
+        Ok(SaveLanguageId::from(language_code[0]))
     }
 
     pub fn get_system_region_from_language_id(language: SaveLanguageId) -> Region {


### PR DESCRIPTION
If we are unable to read save data when trying to get the region during setup, default to UsEnglish. Future boots of the game will have save data and use the correct region.