### PR TITLE
Update panic messages with Arcropolis name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,10 +393,10 @@ pub fn main() {
             },
         };
 
-        let err_msg = format!("SSBU Arcropolis has panicked at '{}', {}", msg, location);
+        let err_msg = format!("Arcropolis has panicked at '{}', {}", msg, location);
         skyline::error::show_error(
             69,
-            "SSBU Arcropolis has panicked! Please open the details and send a screenshot to the developer, then close the game.\n\0",
+            "Arcropolis has panicked! Please open the details and send a screenshot to the developer, then close the game.\n\0",
             err_msg.as_str(),
         );
     }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,10 +393,10 @@ pub fn main() {
             },
         };
 
-        let err_msg = format!("thread has panicked at '{}', {}", msg, location);
+        let err_msg = format!("SSBU Arcropolis has panicked at '{}', {}", msg, location);
         skyline::error::show_error(
             69,
-            "Skyline plugin has panicked! Please open the details and send a screenshot to the developer, then close the game.\n\0",
+            "SSBU Arcropolis has panicked! Please open the details and send a screenshot to the developer, then close the game.\n\0",
             err_msg.as_str(),
         );
     }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,10 +393,10 @@ pub fn main() {
             },
         };
 
-        let err_msg = format!("Arcropolis has panicked at '{}', {}", msg, location);
+        let err_msg = format!("ARCropolis has panicked at '{}', {}", msg, location);
         skyline::error::show_error(
             69,
-            "Arcropolis has panicked! Please open the details and send a screenshot to the developer, then close the game.\n\0",
+            "ARCropolis has panicked! Please open the details and send a screenshot to the developer, then close the game.\n\0",
             err_msg.as_str(),
         );
     }));


### PR DESCRIPTION
Mirroring a [similar change in the Training Modpack repo](https://github.com/jugeeya/UltimateTrainingModpack/blob/main/src/lib.rs#L63-L80), we should specify which plugin panics if we are using a panic handler. This will help shield poor Shadow from issues being posted to Skyline repo, such as... [pretty much all of them lol](https://github.com/skyline-dev/skyline/issues?q=is%3Aissue+is%3Aclosed)