### PR TITLE
Use motion_list.yml instead of motion_list.bin

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -133,7 +133,8 @@ impl CachedFilesystem {
         let mut set = HashSet::new();
         for (root, path) in launchpad.collected_paths().iter() {
             // The collected paths gives us everything so we only want these extensions
-            if path.has_extension("motdiff") {
+            if path.has_extension("motdiff")
+            || path.ends_with("motion_list.yml") {
                 if let Some(hash) = utils::add_motionlist_patch(api_tree, root, path) {
                     set.insert(hash);
                 }

--- a/src/fs/discover.rs
+++ b/src/fs/discover.rs
@@ -123,7 +123,9 @@ pub fn perform_discovery() -> LaunchPad<StandardLoader> {
 
                     "patch3audio",
 
-                    "motdiff"
+                    "motdiff",
+
+                    "yml"
                 ];
                 RESERVED_NAMES.contains(&name) || {
                     let is_out_of_region = if let Some(index) = name.find('+') {

--- a/src/fs/loaders.rs
+++ b/src/fs/loaders.rs
@@ -341,19 +341,67 @@ impl ApiLoadType {
                     return Err(ApiLoaderError::Other("No patches found for file in motion list patch!".to_string()));
                 };
 
+                let mut yml_patches = Vec::new();
+                let mut diff_patches = Vec::new();
+
+                for x in patches.iter() {
+                    if x.has_extension("motdiff") {
+                        diff_patches.push(x.clone());
+                    }
+                    else if x.ends_with("motion_list.yml") {
+                        yml_patches.push(x.clone());
+                    }
+                    else {
+                        return Err(ApiLoaderError::Other("This isn't a motion list patch file!".to_string()));
+                    }
+                }
+
                 let data = ApiLoader::handle_load_base_file(local)?;
                 let mut reader = std::io::Cursor::new(data);
 
                 let mut motion = motion_lib::read_stream(&mut reader)?;
 
-                for patch_path in patches.iter() {
-                    let mut contents: String = String::default();
-                    std::fs::File::open(patch_path)?.read_to_string(&mut contents)?;
-                    if let Some(diff) = from_str(&contents)? {
-                        motion.apply(&diff);
+                if !yml_patches.is_empty() {
+                    println!("[ARCropolis::loader] motion_list.yml file(s) found!");
+                    let mut full_patches = 0;
+
+                    let mut last_read = None;
+
+                    for full_patch in yml_patches.iter() {
+                        last_read = Some(full_patch.clone());
+                        let mut contents: String = String::default();
+                        std::fs::File::open(full_patch)?.read_to_string(&mut contents)?;
+                        if let Some(full) = from_str(&contents)? {
+                            motion = full;
+                            full_patches += 1;
+                        }
                     }
-                    else {
-                        return Err(ApiLoaderError::Other("This isn't a motion list patch file!".to_string()));
+    
+                    if full_patches > 1 {
+                        let mut dialogue : String = "Multiple motion_list.yml files found for ".to_owned();
+                        let local_path = local.to_str().unwrap();
+                        dialogue.push_str(local.to_str().unwrap());
+                        dialogue.push_str(
+                            ".
+                            Using equivalent file from "
+                        );
+                        let used_path = last_read.unwrap().to_str().unwrap().replace("motion_list.yml", "motion_list.bin").replace(local_path, "");
+                        dialogue.push_str(used_path.as_str());
+                        dialogue.push_str(".");
+                        skyline_web::DialogOk::ok(dialogue);
+                    }
+                }
+
+                if !diff_patches.is_empty() {
+                    for patch_path in diff_patches.iter() {
+                        let mut contents: String = String::default();
+                        std::fs::File::open(patch_path)?.read_to_string(&mut contents)?;
+                        if let Some(diff) = from_str(&contents)? {
+                            motion.apply(&diff);
+                        }
+                        else {
+                            return Err(ApiLoaderError::Other("This isn't a motion list patch file!".to_string()));
+                        }
                     }
                 }
                 println!("[ARCropolis::loader] Motion List Patching finished, writing to file...");

--- a/src/fs/utils.rs
+++ b/src/fs/utils.rs
@@ -317,6 +317,6 @@ pub fn add_bgm_property_patch<P: AsRef<Path>, Q: AsRef<Path>>(tree: &mut Tree<Ap
             }
         }
     }
-    error!("Could not add file {} to API tree. Reason: This is not a motion_list.bin file.", full_path.display());
+    error!("Could not add file {} to API tree. Reason: This is not a bgm_property.bin file.", full_path.display());
     None
 }


### PR DESCRIPTION
Implements using decompiled motion lists, named as `motion_list.yml`, as a replacement for a `motion_list.bin`. This will completely overwrite the `motion_list.bin` file with the yml, then apply any `motdiff` patches to it.

If multiple `motion_list.yml` files are found for a single `motion_list.bin`, ARCropolis will warn the user that there are multiple files, and will tell the user which one was the last one that was applied using a Skyline Web dialogue, as shown:

![image](https://user-images.githubusercontent.com/26860994/217467354-37b722a1-ad93-4abe-afec-52ba94c114a7.png)