### PR TITLE
Fix some unsoundness issues

### DIFF
--- a/src/replacement/extensions.rs
+++ b/src/replacement/extensions.rs
@@ -451,8 +451,8 @@ impl LoadedArcEx for LoadedArc {
 
         // Calculate extra folders and set extra folder header for FolderOffsets
         let extra_folder_count =
-            (folder_offsets_vec_len as u32) - (header.folder_offset_count_1 + header.folder_offset_count_2 + header.extra_folder);
-        header.extra_folder += extra_folder_count as u32;
+            (folder_offsets_vec_len as u32).wrapping_sub(header.folder_offset_count_1 + header.folder_offset_count_2 + header.extra_folder);
+        header.extra_folder = header.extra_folder.wrapping_add(extra_folder_count as u32);
         self.folder_offsets = folder_offsets_vec;
         // --------------------- END MODIFY DIRECTORY RELEATED FIELDS ---------------------
 

--- a/src/resource/containers.rs
+++ b/src/resource/containers.rs
@@ -1,7 +1,7 @@
 use std::{
     alloc::Layout,
     ops::{Index, IndexMut, Range},
-    ptr::null,
+    ptr::{NonNull, null},
 };
 
 #[derive(Debug)]
@@ -95,14 +95,22 @@ impl<T> CppVector<T> {
     pub fn as_slice(&self) -> &[T] {
         unsafe {
             let len = self.end.offset_from(self.start) as usize;
-            std::slice::from_raw_parts(self.start, len)
+            if len > 0 {
+                std::slice::from_raw_parts(self.start, len)
+            } else {
+                std::slice::from_raw_parts(NonNull::<T>::dangling().as_ptr(), len)
+            }
         }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         unsafe {
             let len = self.end.offset_from(self.start) as usize;
-            std::slice::from_raw_parts_mut(self.start, len)
+            if len > 0 {
+                std::slice::from_raw_parts_mut(self.start, len)
+            } else {
+                std::slice::from_raw_parts_mut(NonNull::<T>::dangling().as_ptr(), len)
+            }
         }
     }
 


### PR DESCRIPTION
1. The subtraction and addition of `folder_offsets` in extensions.rs intentionally overflows, twice. This was changed to the `wrapping_` version of this operation.
2. vectors obtained from the game may have a nullptr `__begin_` if they are zero-sized. Constructing zero-sized slices  with a null pointer (happens during `make_addition_context()`) is unsound, so a branch was added to handle the case of a zero-sized vector.