### PR TITLE
Prevent NROs from the original game from being double-registered.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ serde_yaml = "0.8"
 smash-bgm-property = "1.2.0"
 # For inputs
 ninput = { git = "https://github.com/blu-dev/ninput" }
+# For reading in NRR hashes
+binrw = "0.11.2"
 
 [patch.crates-io]
 nnsdk = { git = "https://github.com/Raytwo/nnsdk-rs", branch="account_fs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,6 @@ serde_yaml = "0.8"
 smash-bgm-property = "1.2.0"
 # For inputs
 ninput = { git = "https://github.com/blu-dev/ninput" }
-# For reading in NRR hashes
-binrw = "0.11.2"
 
 [patch.crates-io]
 nnsdk = { git = "https://github.com/Raytwo/nnsdk-rs", branch="account_fs" }


### PR DESCRIPTION
This allows for NROs whose hashes are inside the original games' NRR files to replace NROs via ARCropolis.
(ex: replacing ``prebuilt:/nro/release/lua2cpp_roy.nro`` with a byte-identical dump from ``data.arc``) 