### PR TITLE
Remove ShortPatchList error for PRCX patching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ arcropolis-api = { git = "https://github.com/Raytwo/arcropolis_api" }
 arc-config = { git = "https://github.com/blu-dev/arc-config", features = ["runtime"] }
 # For arc:/ and mods:/
 nn-fuse = { git = "https://github.com/Raytwo/nn-fuse" }
-prcx = { git = "https://github.com/blu-dev/prcx", branch = "xml-style" }
+prcx = { git = "https://github.com/zrksyd/prcx", branch = "xml-style-zrksyd" }
 # For xmsbt
 xml-rs = "0.8.15"
 serde-xml-rs = "0.6.0"


### PR DESCRIPTION
I removed the exception for when the patch file is shorter than the source file. I found a hard time explaining in words as to why to do this so I created this visual. It gives better support for added entries and makes patching order commutative. 

![image](https://github.com/Raytwo/ARCropolis/assets/6856627/c3110cac-da13-429e-af41-0847495e3401)